### PR TITLE
xml original das notas

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/ProviderABRASF.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ProviderABRASF.cs
@@ -1375,6 +1375,7 @@ namespace OpenAC.Net.NFSe.Providers
                 nota.IdentificacaoNFSe.Numero = numeroNFSe;
                 nota.IdentificacaoNFSe.Chave = chaveNFSe;
                 nota.IdentificacaoNFSe.DataEmissao = dataNFSe;
+                nota.XmlOriginal = compNfse.ToString();
             }
 
             retornoWebservice.Nota = nota;

--- a/src/OpenAC.Net.NFSe/Providers/ProviderABRASF200.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ProviderABRASF200.cs
@@ -932,6 +932,7 @@ namespace OpenAC.Net.NFSe.Providers
                 {
                     nota.IdentificacaoNFSe.Numero = numeroNFSe;
                     nota.IdentificacaoNFSe.Chave = chaveNFSe;
+                    nota.XmlOriginal = compNfse.ToString();
                 }
 
                 nota.Protocolo = retornoWebservice.Protocolo;
@@ -1053,6 +1054,7 @@ namespace OpenAC.Net.NFSe.Providers
                     nota.IdentificacaoNFSe.Numero = numeroNFSe;
                     nota.IdentificacaoNFSe.Chave = chaveNFSe;
                     nota.IdentificacaoNFSe.DataEmissao = dataNFSe;
+                    nota.XmlOriginal = compNfse.ToString();
                 }
 
                 nota.Protocolo = retornoWebservice.Protocolo;
@@ -1230,6 +1232,7 @@ namespace OpenAC.Net.NFSe.Providers
                 nota.IdentificacaoNFSe.Numero = numeroNFSe;
                 nota.IdentificacaoNFSe.Chave = chaveNFSe;
                 nota.IdentificacaoNFSe.DataEmissao = dataNFSe;
+                nota.XmlOriginal = compNfse.ToString();
             }
 
             retornoWebservice.Nota = nota;

--- a/src/OpenAC.Net.NFSe/Providers/SaoPaulo/ProviderSaoPaulo.cs
+++ b/src/OpenAC.Net.NFSe/Providers/SaoPaulo/ProviderSaoPaulo.cs
@@ -536,6 +536,7 @@ namespace OpenAC.Net.NFSe.Providers
                 {
                     nota.IdentificacaoNFSe.Numero = numeroNFSe;
                     nota.IdentificacaoNFSe.Chave = codigoVerificacao;
+                    nota.XmlOriginal = nfse.ToString();
                 }
 
                 notasServico.Add(nota);
@@ -603,6 +604,7 @@ namespace OpenAC.Net.NFSe.Providers
                 nota.IdentificacaoNFSe.Numero = numeroNFSe;
                 nota.IdentificacaoNFSe.Chave = chaveNFSe;
                 nota.IdentificacaoNFSe.DataEmissao = dataNFSe;
+                nota.XmlOriginal = xmlNFSe.ToString();
             }
 
             retornoWebservice.Nota = nota;


### PR DESCRIPTION
Inclusão do xml original das notas em alguns métodos de consulta e envio síncrono nos provedores ABRASF, ABRASF200 e SaoPaulo