### PR TITLE
ProviderABRASF200: Correção do campo "Sucesso" na consulta de NFSe por RPS

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/ProviderABRASF200.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ProviderABRASF200.cs
@@ -1236,6 +1236,7 @@ namespace OpenAC.Net.NFSe.Providers
             }
 
             retornoWebservice.Nota = nota;
+            retornoWebservice.Sucesso = true;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
O campo "Sucesso" não era atualizado no tratamento do retorno da consulta de nfse por rps no providerabrasf200