### PR TITLE
Colocando MaxReceivedMessageSize na nota Curitibana

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/Curitiba/CuritibaServiceClient.cs
+++ b/src/OpenAC.Net.NFSe/Providers/Curitiba/CuritibaServiceClient.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
+using System.ServiceModel;
 using System.Xml.Linq;
 using OpenAC.Net.Core.Extensions;
 using OpenAC.Net.DFe.Core;
@@ -43,6 +44,12 @@ namespace OpenAC.Net.NFSe.Providers
 
         public CuritibaServiceClient(ProviderCuritiba provider, TipoUrl tipoUrl) : base(provider, tipoUrl)
         {
+            if (!(Endpoint?.Binding is BasicHttpBinding binding))
+                return;
+
+            binding.MaxReceivedMessageSize = long.MaxValue;
+            binding.MaxBufferPoolSize = long.MaxValue;
+            binding.MaxBufferSize = int.MaxValue;
         }
 
         public CuritibaServiceClient(ProviderCuritiba provider, TipoUrl tipoUrl, X509Certificate2 certificado) : base(provider, tipoUrl, certificado)


### PR DESCRIPTION
Colocando MaxReceivedMessageSize maior na nota Curitibana com a finalidade de conseguir capturar mais notas e não apresentar este erro:

> A cota máxima de tamanho de mensagens de entrada (xxxxx) foi excedida. Para aumentar a cota, use a propriedade MaxReceivedMessageSize no elemento de associação apropriado.