### PR TITLE
Diminuindo o MaxReceivedMessageSize da Nota Curitibana

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/Curitiba/CuritibaServiceClient.cs
+++ b/src/OpenAC.Net.NFSe/Providers/Curitiba/CuritibaServiceClient.cs
@@ -47,9 +47,9 @@ namespace OpenAC.Net.NFSe.Providers
             if (!(Endpoint?.Binding is BasicHttpBinding binding))
                 return;
 
-            binding.MaxReceivedMessageSize = long.MaxValue;
-            binding.MaxBufferPoolSize = long.MaxValue;
-            binding.MaxBufferSize = int.MaxValue;
+            binding.MaxReceivedMessageSize = 1000000;
+            binding.MaxBufferPoolSize = 1000000;
+            binding.MaxBufferSize = 1000000;
         }
 
         public CuritibaServiceClient(ProviderCuritiba provider, TipoUrl tipoUrl, X509Certificate2 certificado) : base(provider, tipoUrl, certificado)


### PR DESCRIPTION
Diminuindo o MaxReceivedMessageSize da Nota Curitiba pois foi encontrado o erro:

> Esta fábrica armazena mensagens em buffer e, portanto, os tamanhos das mensagens devem estar no intervalo de um valor inteiro