### PR TITLE
Corrigindo busca de NFS-e por período de Curitiba

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/Curitiba/CuritibaServiceClient.cs
+++ b/src/OpenAC.Net.NFSe/Providers/Curitiba/CuritibaServiceClient.cs
@@ -44,16 +44,16 @@ namespace OpenAC.Net.NFSe.Providers
 
         public CuritibaServiceClient(ProviderCuritiba provider, TipoUrl tipoUrl) : base(provider, tipoUrl)
         {
+        }
+
+        public CuritibaServiceClient(ProviderCuritiba provider, TipoUrl tipoUrl, X509Certificate2 certificado) : base(provider, tipoUrl, certificado)
+        {
             if (!(Endpoint?.Binding is BasicHttpBinding binding))
                 return;
 
             binding.MaxReceivedMessageSize = 1000000;
             binding.MaxBufferPoolSize = 1000000;
             binding.MaxBufferSize = 1000000;
-        }
-
-        public CuritibaServiceClient(ProviderCuritiba provider, TipoUrl tipoUrl, X509Certificate2 certificado) : base(provider, tipoUrl, certificado)
-        {
         }
 
         #endregion Constructors

--- a/src/OpenAC.Net.NFSe/Providers/Curitiba/ProviderCuritiba.cs
+++ b/src/OpenAC.Net.NFSe/Providers/Curitiba/ProviderCuritiba.cs
@@ -1345,7 +1345,7 @@ namespace OpenAC.Net.NFSe.Providers
             var xmlRet = XDocument.Parse(retornoWebservice.XmlRetorno);
             var xmlConsultarNfseResult = xmlRet.ElementAnyNs("ConsultarNfseResponse").ElementAnyNs("ConsultarNfseResult");
             MensagemErro(retornoWebservice, xmlConsultarNfseResult);
-            //if (retornoWebservice.Erros.Any()) return;
+            if (retornoWebservice.Erros.Any()) return;
 
             var retornoLote = xmlRet.ElementAnyNs("ConsultarNfseResponse");
             var listaNfse = retornoLote?.ElementAnyNs("ConsultarNfseResult").ElementAnyNs("ListaNfse");

--- a/src/OpenAC.Net.NFSe/Providers/Curitiba/ProviderCuritiba.cs
+++ b/src/OpenAC.Net.NFSe/Providers/Curitiba/ProviderCuritiba.cs
@@ -1148,6 +1148,9 @@ namespace OpenAC.Net.NFSe.Providers
 
         protected override IServiceClient GetClient(TipoUrl tipo)
         {
+            if (tipo == TipoUrl.ConsultarNFSe)
+                return new CuritibaServiceClient(this, tipo, Certificado);
+
             return new CuritibaServiceClient(this, tipo);
         }
 


### PR DESCRIPTION
Corrigido para inicializar o CuritibaServiceClient mandando o certificado para conseguir pegar as NFS-e de Curitiba por período sem erro