### PR TITLE
Retirada validacao de schema do SystemPro

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/SystemPro/ProviderSystemPro.cs
+++ b/src/OpenAC.Net.NFSe/Providers/SystemPro/ProviderSystemPro.cs
@@ -135,6 +135,14 @@ namespace OpenAC.Net.NFSe.Providers
         }
         #endregion
 
+        #region Abstract
+
+        protected override bool PrecisaValidarSchema(TipoUrl tipo)
+        {
+            return false;
+        }
+        #endregion
+
         #endregion Methods
     }
 }


### PR DESCRIPTION
Não estava localizando o arquivo do schema na maquina do cliente, mas no pc de desenvolvimento sim.

Já olhei nos resources e estava marcado como copy local always.

Então retirei a validação, mas se alguém souber como resolver, fique à vontade.