### PR TITLE
Alteracao para nao validar schema no SystemPro

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/SystemPro/ProviderSystemPro.cs
+++ b/src/OpenAC.Net.NFSe/Providers/SystemPro/ProviderSystemPro.cs
@@ -131,6 +131,16 @@ namespace OpenAC.Net.NFSe.Providers
 
         #endregion Services
 
+        #region Abstract
+
+        protected override bool PrecisaValidarSchema(TipoUrl tipo)
+        {
+            //Coloquei false pois nao estava conseguindo encontrar os schemas na maquina dos usuarios. 
+            //Se alguem souber como resolver, sinta-se a vontade para colocar true
+            return false;
+        }
+        #endregion
+
         #endregion Methods
     }
 }


### PR DESCRIPTION
Coloquei false pois nao estava conseguindo encontrar os schemas na maquina dos usuarios, mesmo estando como copy local = always e funcionando a validação na maquina de desenvolvimento