### PR TITLE
Correções para obtenção da nfse a partir do retorno lote RPS de portovelho.

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/Pvh/ProviderPvh.cs
+++ b/src/OpenAC.Net.NFSe/Providers/Pvh/ProviderPvh.cs
@@ -26,6 +26,37 @@ namespace OpenAC.Net.NFSe.Providers.Pvh
 
         #region Methods
 
+        protected override void LoadPrestador(NotaServico nota, XElement rootNFSe)
+        {
+            // Endereco Prestador
+            var prestadorServico = rootNFSe.ElementAnyNs("PrestadorServico");
+            if (prestadorServico == null) return;
+
+            nota.Prestador.RazaoSocial = prestadorServico.ElementAnyNs("RazaoSocial")?.GetValue<string>() ?? string.Empty;
+            nota.Prestador.NomeFantasia = prestadorServico.ElementAnyNs("NomeFantasia")?.GetValue<string>() ?? string.Empty;
+            nota.Prestador.NomeFantasia = prestadorServico.ElementAnyNs("NomeFantasia")?.GetValue<string>() ?? string.Empty;
+
+            // Endereco Prestador
+            var enderecoPrestador = prestadorServico.ElementAnyNs("Endereco");
+            if (enderecoPrestador != null)
+            {
+                nota.Prestador.Endereco.Logradouro = enderecoPrestador.ElementAnyNs("Endereco")?.GetValue<string>() ?? string.Empty;
+                nota.Prestador.Endereco.Numero = enderecoPrestador.ElementAnyNs("Numero")?.GetValue<string>() ?? string.Empty;
+                nota.Prestador.Endereco.Complemento = enderecoPrestador.ElementAnyNs("Complemento")?.GetValue<string>() ?? string.Empty;
+                nota.Prestador.Endereco.Bairro = enderecoPrestador.ElementAnyNs("Bairro")?.GetValue<string>() ?? string.Empty;
+                nota.Prestador.Endereco.CodigoMunicipio = enderecoPrestador.ElementAnyNs("CodigoMunicipio")?.GetValue<int>() ?? 0;
+                nota.Prestador.Endereco.Uf = enderecoPrestador.ElementAnyNs("Uf")?.GetValue<string>() ?? string.Empty;
+                nota.Prestador.Endereco.Cep = enderecoPrestador.ElementAnyNs("Cep")?.GetValue<string>() ?? string.Empty;
+            }
+
+            // Contato Prestador
+            var contatoPrestador = rootNFSe.ElementAnyNs("Contato");
+            if (contatoPrestador != null)
+            {
+                nota.Prestador.DadosContato.Telefone = contatoPrestador.ElementAnyNs("Telefone")?.GetValue<string>() ?? string.Empty;
+                nota.Prestador.DadosContato.Email = contatoPrestador.ElementAnyNs("Email")?.GetValue<string>() ?? string.Empty;
+            }
+        }
         protected override void LoadTomador(NotaServico nota, XElement rpsRoot)
         {
             // Tomador
@@ -69,11 +100,6 @@ namespace OpenAC.Net.NFSe.Providers.Pvh
             nota.Tomador.DadosContato.Telefone = rootTomadorContato.ElementAnyNs("Telefone")?.GetValue<string>() ?? string.Empty;
             nota.Tomador.DadosContato.Email = rootTomadorContato.ElementAnyNs("Email")?.GetValue<string>() ?? string.Empty;
         }
-        protected override void LoadRps(NotaServico nota, XElement rpsRoot)
-        {
-            base.LoadRps(nota, rpsRoot);
-        }
-
 
         protected override void LoadNFSe(NotaServico nota, XElement rootNFSe)
         {
@@ -212,9 +238,7 @@ namespace OpenAC.Net.NFSe.Providers.Pvh
 
                 switch (regime)
                 {
-                    //case RegimeEspecialTributacao.Nenhum: 
-                    //    regimeEspecialTributacao = "";
-                    //    break;
+
                     case RegimeEspecialTributacao.MicroEmpresaMunicipal:
                         regimeEspecialTributacao = "5";
                         break;
@@ -233,15 +257,7 @@ namespace OpenAC.Net.NFSe.Providers.Pvh
                     case RegimeEspecialTributacao.MicroEmpresarioEmpresaPP:
                         regimeEspecialTributacao = "6";
                         break;
-                    //case RegimeEspecialTributacao.LucroReal:
-                    //    regimeEspecialTributacao = "";
-                    //    break;
-                    //case RegimeEspecialTributacao.LucroPresumido:
-                    //    regimeEspecialTributacao = "";
-                    //    break;
-                    //case RegimeEspecialTributacao.SimplesNacional:
-                    //    regimeEspecialTributacao = "";
-                    //    break;
+
                     default:
                         regimeEspecialTributacao = "1";
                         break;
@@ -249,9 +265,6 @@ namespace OpenAC.Net.NFSe.Providers.Pvh
                 //regimeEspecialTributacao = ((int)nota.RegimeEspecialTributacao).ToString();
                 optanteSimplesNacional = "2";
             }
-
-            //if (nota.RegimeEspecialTributacao != RegimeEspecialTributacao.Nenhum)
-            //    infServico.AddChild(AdicionarTag(TipoCampo.Int, "", "RegimeEspecialTributacao", 1, 1, Ocorrencia.NaoObrigatoria, regimeEspecialTributacao));
 
             infServico.AddChild(AdicionarTag(TipoCampo.Int, "", "RegimeEspecialTributacao", 1, 1, Ocorrencia.NaoObrigatoria, regimeEspecialTributacao));
             infServico.AddChild(AdicionarTag(TipoCampo.Int, "", "OptanteSimplesNacional", 1, 1, Ocorrencia.Obrigatoria, optanteSimplesNacional));

--- a/src/OpenAC.Net.NFSe/Providers/Pvh/ProviderPvh.cs
+++ b/src/OpenAC.Net.NFSe/Providers/Pvh/ProviderPvh.cs
@@ -1,4 +1,5 @@
-﻿using OpenAC.Net.Core.Extensions;
+﻿using OpenAC.Net.Core;
+using OpenAC.Net.Core.Extensions;
 using OpenAC.Net.DFe.Core.Serializer;
 using OpenAC.Net.NFSe.Configuracao;
 using OpenAC.Net.NFSe.Nota;
@@ -7,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Linq;
 
 namespace OpenAC.Net.NFSe.Providers.Pvh
@@ -23,6 +25,134 @@ namespace OpenAC.Net.NFSe.Providers.Pvh
         #endregion
 
         #region Methods
+
+        protected override void LoadTomador(NotaServico nota, XElement rpsRoot)
+        {
+            // Tomador
+            var rootTomador = rpsRoot.ElementAnyNs("Tomador");
+            if (rootTomador == null) return;
+
+            var tomadorIdentificacao = rootTomador.ElementAnyNs("IdentificacaoTomador");
+            if (tomadorIdentificacao != null)
+            {
+                nota.Tomador.CpfCnpj = tomadorIdentificacao.ElementAnyNs("CpfCnpj")?.GetCPF_CNPJ();
+                nota.Tomador.InscricaoMunicipal = tomadorIdentificacao.ElementAnyNs("InscricaoMunicipal")?.GetValue<string>() ?? string.Empty;
+            }
+
+            nota.Tomador.DocTomadorEstrangeiro = rootTomador.ElementAnyNs("NifTomador")?.GetValue<string>() ?? string.Empty;
+            nota.Tomador.RazaoSocial = rootTomador.ElementAnyNs("RazaoSocial")?.GetValue<string>() ?? string.Empty;
+
+            var endereco = rootTomador.ElementAnyNs("Endereco");
+            if (endereco != null)
+            {
+                nota.Tomador.Endereco.Logradouro = endereco.ElementAnyNs("Endereco")?.GetValue<string>() ?? string.Empty;
+                nota.Tomador.Endereco.Numero = endereco.ElementAnyNs("Numero")?.GetValue<string>() ?? string.Empty;
+                nota.Tomador.Endereco.Complemento = endereco.ElementAnyNs("Complemento")?.GetValue<string>() ?? string.Empty;
+                nota.Tomador.Endereco.Bairro = endereco.ElementAnyNs("Bairro")?.GetValue<string>() ?? string.Empty;
+                nota.Tomador.Endereco.CodigoMunicipio = endereco.ElementAnyNs("CodigoMunicipio")?.GetValue<int>() ?? 0;
+                nota.Tomador.Endereco.Uf = endereco.ElementAnyNs("Uf")?.GetValue<string>() ?? string.Empty;
+                nota.Tomador.Endereco.CodigoPais = endereco.ElementAnyNs("CodigoPais")?.GetValue<int>() ?? 0;
+                nota.Tomador.Endereco.Cep = endereco.ElementAnyNs("Cep")?.GetValue<string>() ?? string.Empty;
+            }
+
+            var enderecoExterior = rootTomador.ElementAnyNs("EnderecoExterior");
+            if (enderecoExterior != null)
+            {
+                nota.Tomador.EnderecoExterior.CodigoPais = enderecoExterior.ElementAnyNs("CodigoPais")?.GetValue<int>() ?? 0;
+                nota.Tomador.EnderecoExterior.EnderecoCompleto = enderecoExterior.ElementAnyNs("EnderecoCompletoExterior")?.GetValue<string>() ?? string.Empty;
+            }
+
+            var rootTomadorContato = rootTomador.ElementAnyNs("Contato");
+            if (rootTomadorContato == null) return;
+
+            nota.Tomador.DadosContato.DDD = "";
+            nota.Tomador.DadosContato.Telefone = rootTomadorContato.ElementAnyNs("Telefone")?.GetValue<string>() ?? string.Empty;
+            nota.Tomador.DadosContato.Email = rootTomadorContato.ElementAnyNs("Email")?.GetValue<string>() ?? string.Empty;
+        }
+        protected override void LoadRps(NotaServico nota, XElement rpsRoot)
+        {
+            base.LoadRps(nota, rpsRoot);
+        }
+
+
+        protected override void LoadNFSe(NotaServico nota, XElement rootNFSe)
+        {
+            nota.IdentificacaoNFSe.Numero = rootNFSe.ElementAnyNs("Numero")?.GetValue<string>() ?? string.Empty;
+            nota.IdentificacaoNFSe.Chave = rootNFSe.ElementAnyNs("CodigoVerificacao")?.GetValue<string>() ?? string.Empty;
+            nota.IdentificacaoNFSe.DataEmissao = rootNFSe.ElementAnyNs("DataEmissao")?.GetValue<DateTime>() ?? DateTime.MinValue;
+
+            nota.RpsSubstituido.NumeroNfse = rootNFSe.ElementAnyNs("NfseSubstituida")?.GetValue<string>() ?? string.Empty;
+            nota.OutrasInformacoes = rootNFSe.ElementAnyNs("OutrasInformacoes")?.GetValue<string>() ?? string.Empty;
+
+            // Valores NFSe
+            var valoresNFSe = rootNFSe.ElementAnyNs("ValoresNfse");
+            if (valoresNFSe != null)
+            {
+                nota.Servico.Valores.BaseCalculo = valoresNFSe.ElementAnyNs("BaseCalculo")?.GetValue<decimal>() ?? 0;
+                nota.Servico.Valores.ValorIss = valoresNFSe.ElementAnyNs("ValorIss")?.GetValue<decimal>() ?? 0;
+                nota.Servico.Valores.ValorLiquidoNfse = valoresNFSe.ElementAnyNs("ValorLiquidoNfse")?.GetValue<decimal>() ?? 0;
+
+                var aliquota = valoresNFSe.ElementAnyNs("Aliquota")?.GetValue<decimal>() ?? 0;
+
+                // Aliquota vem bruta na nfse de portovelho
+                if (aliquota != 0)
+                    nota.Servico.Valores.Aliquota = aliquota / 100;
+            }
+
+            nota.DescricaoCodigoTributacaoMunicipio = rootNFSe.ElementAnyNs("DescricaoCodigoTributacaoMunicípio")?.GetValue<string>() ?? string.Empty;
+            nota.ValorCredito = rootNFSe.ElementAnyNs("ValorCredito")?.GetValue<decimal>() ?? 0;
+
+            LoadPrestador(nota, rootNFSe);
+
+            // Orgão Gerador
+            var rootOrgaoGerador = rootNFSe.ElementAnyNs("OrgaoGerador");
+            if (rootOrgaoGerador == null) return;
+
+            nota.OrgaoGerador.CodigoMunicipio = rootOrgaoGerador.ElementAnyNs("CodigoMunicipio")?.GetValue<int>() ?? 0;
+            nota.OrgaoGerador.Uf = rootOrgaoGerador.ElementAnyNs("Uf")?.GetValue<string>() ?? string.Empty;
+        }
+
+        public override NotaServico LoadXml(XDocument xml)
+        {
+            Guard.Against<XmlException>(xml == null, "Xml invalido.");
+
+            XElement rootNFSe = null;
+            XElement rootCanc = null;
+            XElement rootSub = null;
+            XElement rootRps;
+
+            var rootGrupo = xml.ElementAnyNs("ConsultarLoteRpsResposta");
+            var rootGrupoListaNfse = rootGrupo?.ElementAnyNs("ListaNfse");
+            var rootCompNfse = rootGrupoListaNfse?.ElementAnyNs("CompNfse");
+
+            if (rootCompNfse != null)
+            {
+                rootNFSe = rootCompNfse.ElementAnyNs("Nfse")?.ElementAnyNs("InfNfse");
+                rootCanc = rootCompNfse.ElementAnyNs("NfseCancelamento");
+                rootSub = rootCompNfse.ElementAnyNs("NfseSubstituicao");
+                rootRps = rootNFSe.ElementAnyNs("DeclaracaoPrestacaoServico")?.ElementAnyNs("InfDeclaracaoPrestacaoServico");
+            }
+            else
+            {
+                rootRps = xml.ElementAnyNs("Rps").ElementAnyNs("InfDeclaracaoPrestacaoServico");
+            }
+
+            Guard.Against<XmlException>(rootNFSe == null && rootRps == null, "Xml de RPS ou NFSe invalido.");
+
+            var ret = new NotaServico(Configuracoes);
+
+            if (rootRps != null) //Goiania não retorna o RPS, somente a NFSe
+                LoadRps(ret, rootRps);
+
+            if (rootNFSe != null)
+            {
+                LoadNFSe(ret, rootNFSe);
+                if (rootSub != null) LoadNFSeSub(ret, rootSub);
+                if (rootCanc != null) LoadNFSeCancel(ret, rootCanc);
+            }
+
+            return ret;
+        }
         protected override IServiceClient GetClient(TipoUrl tipo)
         {
             return new PvhServiceClient(this, tipo);


### PR DESCRIPTION
Foi alterado alguns dados (ex: endereço remetente)  que são trazidos em campos diferentes do padrão 