### PR TITLE
[*] Correção do método TratarRetornoConsultarLoteRps para o provedor …

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/SaoPaulo/ProviderSaoPaulo.cs
+++ b/src/OpenAC.Net.NFSe/Providers/SaoPaulo/ProviderSaoPaulo.cs
@@ -538,6 +538,7 @@ namespace OpenAC.Net.NFSe.Providers
                 {
                     nota.IdentificacaoNFSe.Numero = numeroNFSe;
                     nota.IdentificacaoNFSe.Chave = codigoVerificacao;
+                    nota.IdentificacaoNFSe.DataEmissao = dataNFSe;
                     nota.XmlOriginal = nfse.ToString();
                 }
 


### PR DESCRIPTION
…de São Paulo

No método TratarRetornoConsultarLoteRps para o provedor de São Paulo, quando a NFSe já estava na collection, não estava gravando a data de emissão da NFSe vinda do retorno da consulta.