### PR TITLE
Adicionando Target para NET48

### DIFF
--- a/src/OpenAC.Net.NFSe/OpenAC.Net.NFSe.csproj
+++ b/src/OpenAC.Net.NFSe/OpenAC.Net.NFSe.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net48;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyName>OpenAC.Net.NFSe</AssemblyName>
     <RootNamespace>OpenAC.Net.NFSe</RootNamespace>


### PR DESCRIPTION
Ao utilizar o pacote nuget em um projeto cujo target é net48, em vez de utilizar a dll da versão 452 o visual studio usa a netstandard, fazendo com que nada funcione. Deixo esse PR aqui pra discutirmos a viabilidade de suportar as versões mais novas