### PR TITLE
Separa o cabecalho em string para facilitar debug

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/ProviderBase.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ProviderBase.cs
@@ -338,7 +338,8 @@ public abstract class ProviderBase : IOpenLog, IDisposable
 
             using (var cliente = GetClient(TipoUrl.Enviar))
             {
-                retornoWebservice.XmlRetorno = cliente.Enviar(GerarCabecalho(), retornoWebservice.XmlEnvio);
+                string cabec = GerarCabecalho();
+                retornoWebservice.XmlRetorno = cliente.Enviar(cabec, retornoWebservice.XmlEnvio);
                 retornoWebservice.EnvelopeEnvio = cliente.EnvelopeEnvio;
                 retornoWebservice.EnvelopeRetorno = cliente.EnvelopeRetorno;
             }


### PR DESCRIPTION
Evita que seja necessário entrar no método GerarCabecalho quando se deseja deputar o método Enviar

![image](https://user-images.githubusercontent.com/4941173/232864994-680cf686-95fd-4b96-8136-3b4533392daa.png)

Coloca o BreakPoint no método Enviar e vai direto ao que interessa.