### PR TITLE
Chave privada para assinar RPS em São Paulo

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/ISSSaoPaulo/ProviderISSSaoPaulo.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ISSSaoPaulo/ProviderISSSaoPaulo.cs
@@ -31,7 +31,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;

--- a/src/OpenAC.Net.NFSe/Providers/ISSSaoPaulo/ProviderISSSaoPaulo.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ISSSaoPaulo/ProviderISSSaoPaulo.cs
@@ -31,6 +31,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Security.Cryptography;
@@ -815,7 +816,7 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
                    issRetidoIntermediario;
         }
 
-        var rsa = (RSA)Certificado.GetRSAPublicKey();
+        var rsa = Certificado.GetRSAPrivateKey();
         var hashBytes = Encoding.ASCII.GetBytes(hash);
         var signData = rsa.SignData(hashBytes, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
         return Convert.ToBase64String(signData);


### PR DESCRIPTION
Utilizando a chave pública para assinar o RPS recebia o erro "Key does not exists", pois a assinatura deve ser realizada com a chave privada e a chave pública é para validar a assinatura.