### PR TITLE
Para SmarAPD, o código do status de cancelamento é 2

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/ProviderABRASF200.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ProviderABRASF200.cs
@@ -127,13 +127,7 @@ public abstract class ProviderABRASF200 : ProviderBase
         {
             nota.IdentificacaoRps.DataEmissao = rps.ElementAnyNs("DataEmissao")?.GetValue<DateTime>() ?? DateTime.MinValue;
 
-            var situacao = rps.ElementAnyNs("Status")?.GetValue<string>();
-
-            //SmarAPD, a situação para cancelamento é 2
-            if (string.IsNullOrEmpty(situacao) || situacao == "0")
-                nota.Situacao = SituacaoNFSeRps.Normal;
-            else
-                nota.Situacao = SituacaoNFSeRps.Cancelado;
+            nota.Situacao = rps.ElementAnyNs("Status")?.GetValue<SituacaoNFSeRps>() ?? SituacaoNFSeRps.Normal;
 
             var ideRps = rps.ElementAnyNs("IdentificacaoRps");
             if (ideRps != null)
@@ -1133,7 +1127,7 @@ public abstract class ProviderABRASF200 : ProviderBase
         nota.Cancelamento.Pedido.CodigoCancelamento = retornoWebservice.CodigoCancelamento;
         nota.Cancelamento.DataHora = retornoWebservice.Data;
         nota.Cancelamento.MotivoCancelamento = retornoWebservice.Motivo;
-        nota.Cancelamento.Signature = DFeSignature.Load(confirmacaoCancelamento.ElementAnyNs("Pedido").ElementAnyNs("Signature")?.ToString());
+        nota.Cancelamento.Signature = confirmacaoCancelamento.ElementAnyNs("Pedido").ElementAnyNs("Signature") != null ? DFeSignature.Load(confirmacaoCancelamento.ElementAnyNs("Pedido").ElementAnyNs("Signature")?.ToString()) : null;
     }
 
     /// <inheritdoc />

--- a/src/OpenAC.Net.NFSe/Providers/ProviderABRASF200.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ProviderABRASF200.cs
@@ -126,7 +126,14 @@ public abstract class ProviderABRASF200 : ProviderBase
         if (rps != null)
         {
             nota.IdentificacaoRps.DataEmissao = rps.ElementAnyNs("DataEmissao")?.GetValue<DateTime>() ?? DateTime.MinValue;
-            nota.Situacao = rps.ElementAnyNs("Status")?.GetValue<SituacaoNFSeRps>() ?? SituacaoNFSeRps.Normal;
+
+            var situacao = rps.ElementAnyNs("Status")?.GetValue<string>();
+
+            //SmarAPD, a situação para cancelamento é 2
+            if (string.IsNullOrEmpty(situacao) || situacao == "0")
+                nota.Situacao = SituacaoNFSeRps.Normal;
+            else
+                nota.Situacao = SituacaoNFSeRps.Cancelado;
 
             var ideRps = rps.ElementAnyNs("IdentificacaoRps");
             if (ideRps != null)

--- a/src/OpenAC.Net.NFSe/Providers/SmarAPD/ProviderSmarAPD204.cs
+++ b/src/OpenAC.Net.NFSe/Providers/SmarAPD/ProviderSmarAPD204.cs
@@ -29,7 +29,10 @@
 // <summary></summary>
 // ***********************************************************************
 
+using System.Xml.Linq;
+using OpenAC.Net.Core.Extensions;
 using OpenAC.Net.NFSe.Configuracao;
+using OpenAC.Net.NFSe.Nota;
 
 namespace OpenAC.Net.NFSe.Providers;
 
@@ -51,6 +54,23 @@ internal sealed class ProviderSmarAPD204 : ProviderABRASF204
     protected override IServiceClient GetClient(TipoUrl tipo)
     {
         return new SmarAPD204ServiceClient(this, tipo, Certificado);
+    }
+
+    protected override void LoadRps(NotaServico nota, XElement rpsRoot)
+    {
+        base.LoadRps(nota, rpsRoot);
+
+        var rps = rpsRoot.ElementAnyNs("Rps");
+        if (rps != null)
+        {
+            var situacao = rps.ElementAnyNs("Status")?.GetValue<string>();
+
+            //SmarAPD, a situação para cancelamento é 2
+            if (situacao == "1")
+                nota.Situacao = SituacaoNFSeRps.Normal;
+            else
+                nota.Situacao = SituacaoNFSeRps.Cancelado;
+        }
     }
 
     #endregion Protected Methods


### PR DESCRIPTION
Alteração para checagem de notas canceladas ao carregar o RPS, para contemplar a SmarAPD, onde o código de cancelamento é 2 no campo status