### PR TITLE
Alteração para volta da versão da biblioteca OpenAC.Net.DFe.Core

### DIFF
--- a/src/OpenAC.Net.NFSe.DANFSe.FastReport.OpenSource/OpenAC.Net.NFSe.DANFSe.FastReport.OpenSource.csproj
+++ b/src/OpenAC.Net.NFSe.DANFSe.FastReport.OpenSource/OpenAC.Net.NFSe.DANFSe.FastReport.OpenSource.csproj
@@ -47,7 +47,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 	<PackageReference Include="OpenAC.Net.Core" Version="1.5.0.1" />
-    <PackageReference Include="OpenAC.Net.DFe.Core" Version="1.5.0.3" />
+    <PackageReference Include="OpenAC.Net.DFe.Core" Version="1.5.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net470' or '$(TargetFramework)' == 'net48'">

--- a/src/OpenAC.Net.NFSe.DANFSe.FastReport/OpenAC.Net.NFSe.DANFSe.FastReport.csproj
+++ b/src/OpenAC.Net.NFSe.DANFSe.FastReport/OpenAC.Net.NFSe.DANFSe.FastReport.csproj
@@ -68,7 +68,7 @@
       <Version>1.5.0.1</Version>
     </PackageReference>
     <PackageReference Include="OpenAC.Net.DFe.Core">
-      <Version>1.5.0.3</Version>
+      <Version>1.5.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenAC.Net.NFSe.Demo/OpenAC.Net.NFSe.Demo.csproj
+++ b/src/OpenAC.Net.NFSe.Demo/OpenAC.Net.NFSe.Demo.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="NLog" Version="5.1.5" />
     <PackageReference Include="NLog.Windows.Forms" Version="5.0.0" />
     <PackageReference Include="OpenAC.Net.Core" Version="1.5.0.1" />
-    <PackageReference Include="OpenAC.Net.DFe.Core" Version="1.5.0.3" />
+    <PackageReference Include="OpenAC.Net.DFe.Core" Version="1.5.0.2" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
   </ItemGroup>
   

--- a/src/OpenAC.Net.NFSe.Test/OpenAC.Net.NFSe.Test.csproj
+++ b/src/OpenAC.Net.NFSe.Test/OpenAC.Net.NFSe.Test.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="OpenAC.Net.DFe.Core" Version="1.5.0.2" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/OpenAC.Net.NFSe/OpenAC.Net.NFSe.csproj
+++ b/src/OpenAC.Net.NFSe/OpenAC.Net.NFSe.csproj
@@ -37,7 +37,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="OpenAC.Net.Core" Version="1.5.0.1" />
-		<PackageReference Include="OpenAC.Net.DFe.Core" Version="1.5.0.3" />
+		<PackageReference Include="OpenAC.Net.DFe.Core" Version="1.5.0.2" />
 		<PackageReference Include="System.ServiceModel.Http" Version="4.10.2" />
 		<PackageReference Include="System.ServiceModel.Primitives" Version="4.10.2" />		
 	</ItemGroup>


### PR DESCRIPTION
Alteração para volta da versão da biblioteca OpenAC.Net.DFe.Core para 1.5.0.2. A versão 1.0.5.3 não existe