### PR TITLE
Alteração URLs prefeitura de Belo Horizonte MG

### DIFF
--- a/src/OpenAC.Net.NFSe/Resources/Municipios.nfse
+++ b/src/OpenAC.Net.NFSe/Resources/Municipios.nfse
@@ -1087,42 +1087,42 @@
       <UrlProducao>
         <Item>
           <TipoUrl>Enviar</TipoUrl>
-          <Url>https://bhissdigital.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
+          <Url>https://bhissdigitalws.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
         </Item>
         <Item>
           <TipoUrl>EnviarSincrono</TipoUrl>
-          <Url>https://bhissdigital.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
+          <Url>https://bhissdigitalws.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
         </Item>
         <Item>
           <TipoUrl>CancelarNFSe</TipoUrl>
-          <Url>https://bhissdigital.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
+          <Url>https://bhissdigitalws.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
         </Item>
         <Item>
           <TipoUrl>CancelarNFSeLote</TipoUrl>
         </Item>
         <Item>
           <TipoUrl>ConsultarNFSe</TipoUrl>
-          <Url>https://bhissdigital.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
+          <Url>https://bhissdigitalws.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
         </Item>
         <Item>
           <TipoUrl>ConsultarNFSeRps</TipoUrl>
-          <Url>https://bhissdigital.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
+          <Url>https://bhissdigitalws.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
         </Item>
         <Item>
           <TipoUrl>ConsultarLoteRps</TipoUrl>
-          <Url>https://bhissdigital.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
+          <Url>https://bhissdigitalws.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
         </Item>
         <Item>
           <TipoUrl>ConsultarSituacao</TipoUrl>
-          <Url>https://bhissdigital.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
+          <Url>https://bhissdigitalws.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
         </Item>
         <Item>
           <TipoUrl>ConsultarSequencialRps</TipoUrl>
-          <Url>https://bhissdigital.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
+          <Url>https://bhissdigitalws.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
         </Item>
         <Item>
           <TipoUrl>SubstituirNFSe</TipoUrl>
-          <Url>https://bhissdigital.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
+          <Url>https://bhissdigitalws.pbh.gov.br/bhiss-ws/nfse?wsdl</Url>
         </Item>
         <Item>
           <TipoUrl>Autenticacao</TipoUrl>


### PR DESCRIPTION
Ajustado conforme aviso publicado em 24/10/2023 no site da Prefeitura de Belo Horizonte

https://prefeitura.pbh.gov.br/fazenda/bhiss/avisos?combine=&field_tema_value=All&field_data_publicacao_value%5Bmin%5D=2023-10-24&field_data_publicacao_value%5Bmax%5D=2023-10-24