### PR TITLE
Load XML Abrasf

### DIFF
--- a/src/OpenAC.Net.NFSe/Nota/NotaServico.cs
+++ b/src/OpenAC.Net.NFSe/Nota/NotaServico.cs
@@ -137,12 +137,12 @@ public sealed class NotaServico : GenericClone<NotaServico>, INotifyPropertyChan
     public RegimeEspecialTributacao RegimeEspecialTributacao { get; set; }
 
     public NFSeSimNao OptanteSimplesNacional { get; set; }
-    
+
     public NFSeSimNao OptanteMEISimei { get; set; }
 
     public DateTime DataOptanteSimplesNacional { get; set; }
 
-    public NFSeSimNao IncentivadorCultural { get; set; }
+    public NFSeSimNao? IncentivadorCultural { get; set; }
 
     public NFSeSimNao Producao { get; set; }
 
@@ -151,7 +151,7 @@ public sealed class NotaServico : GenericClone<NotaServico>, INotifyPropertyChan
     public TipoLocalServico LocalServico { get; set; }
 
     public int NumeroLote { get; set; }
-    
+
     public string Protocolo { get; set; }
 
     public DateTime Competencia { get; set; }
@@ -159,7 +159,7 @@ public sealed class NotaServico : GenericClone<NotaServico>, INotifyPropertyChan
     public string OutrasInformacoes { get; set; }
 
     public string DiscriminacaoImpostos { get; set; }
-    
+
     public string InformacoesComplementares { get; set; }
 
     public string DescricaoCodigoTributacaoMunicipio { get; set; }
@@ -177,7 +177,7 @@ public sealed class NotaServico : GenericClone<NotaServico>, INotifyPropertyChan
     public DFeSignature Signature { get; set; }
 
     public string XmlOriginal { get; set; }
-    
+
     public string LinkNFSe { get; set; }
 
     public EventoRps? Evento { get; set; }

--- a/src/OpenAC.Net.NFSe/Providers/ProviderABRASF200.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ProviderABRASF200.cs
@@ -253,11 +253,6 @@ public abstract class ProviderABRASF200 : ProviderBase
             case 2:
                 nota.IncentivadorCultural = NFSeSimNao.Nao;
                 break;
-
-            // como o campo IncentivadorCultural não é nullable, caso não esteja presente no XML, por padrão ele ficaria como NÃO
-            default:
-                nota.IncentivadorCultural = NFSeSimNao.Nao;
-                break;
         }
     }
 

--- a/src/OpenAC.Net.NFSe/Providers/ProviderABRASF200.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ProviderABRASF200.cs
@@ -115,7 +115,7 @@ public abstract class ProviderABRASF200 : ProviderBase
             LoadRps(ret, rootRps);
 
         if (rootNFSe == null) return ret;
-        
+
         LoadNFSe(ret, rootNFSe);
         if (rootSub != null) LoadNFSeSub(ret, rootSub);
         if (rootCanc != null) LoadNFSeCancelada(ret, rootCanc);
@@ -173,8 +173,9 @@ public abstract class ProviderABRASF200 : ProviderBase
 
             nota.Servico.Valores.IssRetido = (rootServico.ElementAnyNs("IssRetido")?.GetValue<int>() ?? 0) == 1 ? SituacaoTributaria.Retencao : SituacaoTributaria.Normal;
 
+            // No xml o campo ReponsavelRetencao é gerado como 1 - Tomador / 2 - Prestador
             if (rootServico.ElementAnyNs("ResponsavelRetencao") != null)
-                nota.Servico.ResponsavelRetencao = rootServico.ElementAnyNs("ResponsavelRetencao").GetValue<int>() == 1 ? ResponsavelRetencao.Prestador : ResponsavelRetencao.Tomador;
+                nota.Servico.ResponsavelRetencao = rootServico.ElementAnyNs("ResponsavelRetencao").GetValue<int>() == 2 ? ResponsavelRetencao.Prestador : ResponsavelRetencao.Tomador;
 
             nota.Servico.ItemListaServico = rootServico.ElementAnyNs("ItemListaServico")?.GetValue<string>() ?? string.Empty;
             nota.Servico.CodigoCnae = rootServico.ElementAnyNs("CodigoCnae")?.GetValue<string>() ?? string.Empty;
@@ -250,6 +251,11 @@ public abstract class ProviderABRASF200 : ProviderBase
                 break;
 
             case 2:
+                nota.IncentivadorCultural = NFSeSimNao.Nao;
+                break;
+
+            // como o campo IncentivadorCultural não é nullable, caso não esteja presente no XML, por padrão ele ficaria como NÃO
+            default:
                 nota.IncentivadorCultural = NFSeSimNao.Nao;
                 break;
         }
@@ -503,21 +509,21 @@ public abstract class ProviderABRASF200 : ProviderBase
     {
         var valores = new XElement("Valores");
 
-            valores.AddChild(AddTag(TipoCampo.De2, "", "ValorServicos", 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.ValorServicos));
-            valores.AddChild(AddTag(TipoCampo.De2, "", "ValorDeducoes", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorDeducoes));
-            valores.AddChild(AddTag(TipoCampo.De2, "", "ValorPis", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorPis));
-            valores.AddChild(AddTag(TipoCampo.De2, "", "ValorCofins", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorCofins));
-            valores.AddChild(AddTag(TipoCampo.De2, "", "ValorInss", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorInss));
-            valores.AddChild(AddTag(TipoCampo.De2, "", "ValorIr", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorIr));
-            valores.AddChild(AddTag(TipoCampo.De2, "", "ValorCsll", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorCsll));
-            valores.AddChild(AddTag(TipoCampo.De2, "", "OutrasRetencoes", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.OutrasRetencoes));
-            valores.AddChild(AddTag(TipoCampo.De2, "", "ValorIss", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorIss));
-            if (Municipio.Provedor == NFSeProvider.Fiorilli)
-                valores.AddChild(AddTag(TipoCampo.De4, "", "Aliquota", 1, 6, Ocorrencia.Obrigatoria, nota.Servico.Valores.Aliquota));
-            else
-                valores.AddChild(AddTag(TipoCampo.De4, "", "Aliquota", 1, 6, Ocorrencia.MaiorQueZero, nota.Servico.Valores.Aliquota));
-            valores.AddChild(AddTag(TipoCampo.De2, "", "DescontoIncondicionado", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.DescontoIncondicionado));
-            valores.AddChild(AddTag(TipoCampo.De2, "", "DescontoCondicionado", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.DescontoCondicionado));
+        valores.AddChild(AddTag(TipoCampo.De2, "", "ValorServicos", 1, 15, Ocorrencia.Obrigatoria, nota.Servico.Valores.ValorServicos));
+        valores.AddChild(AddTag(TipoCampo.De2, "", "ValorDeducoes", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorDeducoes));
+        valores.AddChild(AddTag(TipoCampo.De2, "", "ValorPis", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorPis));
+        valores.AddChild(AddTag(TipoCampo.De2, "", "ValorCofins", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorCofins));
+        valores.AddChild(AddTag(TipoCampo.De2, "", "ValorInss", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorInss));
+        valores.AddChild(AddTag(TipoCampo.De2, "", "ValorIr", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorIr));
+        valores.AddChild(AddTag(TipoCampo.De2, "", "ValorCsll", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorCsll));
+        valores.AddChild(AddTag(TipoCampo.De2, "", "OutrasRetencoes", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.OutrasRetencoes));
+        valores.AddChild(AddTag(TipoCampo.De2, "", "ValorIss", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.ValorIss));
+        if (Municipio.Provedor == NFSeProvider.Fiorilli)
+            valores.AddChild(AddTag(TipoCampo.De4, "", "Aliquota", 1, 6, Ocorrencia.Obrigatoria, nota.Servico.Valores.Aliquota));
+        else
+            valores.AddChild(AddTag(TipoCampo.De4, "", "Aliquota", 1, 6, Ocorrencia.MaiorQueZero, nota.Servico.Valores.Aliquota));
+        valores.AddChild(AddTag(TipoCampo.De2, "", "DescontoIncondicionado", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.DescontoIncondicionado));
+        valores.AddChild(AddTag(TipoCampo.De2, "", "DescontoCondicionado", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.DescontoCondicionado));
 
         return valores;
     }
@@ -1409,10 +1415,10 @@ public abstract class ProviderABRASF200 : ProviderBase
         pedidoCancelamento.Append($"<Numero>{retornoWebservice.NumeroNFSe}</Numero>");
         pedidoCancelamento.Append("<CpfCnpj>");
         pedidoCancelamento.Append(Configuracoes.PrestadorPadrao.CpfCnpj.IsCNPJ() ? $"<Cnpj>{Configuracoes.PrestadorPadrao.CpfCnpj.ZeroFill(14)}</Cnpj>" : $"<Cpf>{Configuracoes.PrestadorPadrao.CpfCnpj.ZeroFill(11)}</Cpf>");
-        pedidoCancelamento.Append("</CpfCnpj>"); 
-        
+        pedidoCancelamento.Append("</CpfCnpj>");
+
         if (!Configuracoes.PrestadorPadrao.InscricaoMunicipal.IsEmpty()) pedidoCancelamento.Append($"<InscricaoMunicipal>{Configuracoes.PrestadorPadrao.InscricaoMunicipal}</InscricaoMunicipal>");
-        
+
         pedidoCancelamento.Append($"<CodigoMunicipio>{Configuracoes.PrestadorPadrao.Endereco.CodigoMunicipio}</CodigoMunicipio>");
         pedidoCancelamento.Append("</IdentificacaoNfse>");
         pedidoCancelamento.Append($"<CodigoCancelamento>{retornoWebservice.CodigoCancelamento}</CodigoCancelamento>");
@@ -1491,7 +1497,7 @@ public abstract class ProviderABRASF200 : ProviderBase
         var notaSubistituida = LoadXml(compNfse.ToString());
 
         nota = notas.FirstOrDefault(x => x.IdentificacaoRps.Numero == notaSubistituida.IdentificacaoRps.Numero);
-        
+
         if (nota == null)
         {
             notas.Add(notaSubistituida);


### PR DESCRIPTION
Ao carregar um XML previamente gerado, encontrei dois problemas.
1 - Quando o campo ResponsavelRetencao está presente no XML, estava sendo carregado errado, pois ao gerar o XML os campos são gerados como 1 - Tomador / 2 - Prestador, contudo, ao carregar, estava tratando como se fosse 0 e 1, não 1 e 2.

2 - O campo IncentivadorCultural na classe NotaServico é não nullable, e por conta da posição SIM do enum NFSeSimNao vir primeiro, esse camo sempre recebe SIM por padrão, porém ao carregar o XML, quando este campo não está presente, estava adotando SIM, quando na verdade deveria ficar NÃO, pois caso a empresa seja incentivadora cultural, isso deveria estar explícito no XML, não devendo adotar SIM implicitamente.