### PR TITLE
Alterado tipo da série para o provider ABRASF

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/ProviderABRASF.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ProviderABRASF.cs
@@ -464,7 +464,7 @@ public abstract class ProviderABRASF : ProviderBase
 
         var ideRps = new XElement("IdentificacaoRps");
         ideRps.AddChild(AddTag(TipoCampo.Int, "", "Numero", 1, 15, Ocorrencia.Obrigatoria, nota.IdentificacaoRps.Numero));
-        ideRps.AddChild(AddTag(TipoCampo.Int, "", "Serie", 1, 5, Ocorrencia.Obrigatoria, nota.IdentificacaoRps.Serie));
+        ideRps.AddChild(AddTag(TipoCampo.Str, "", "Serie", 1, 5, Ocorrencia.Obrigatoria, nota.IdentificacaoRps.Serie));
         ideRps.AddChild(AddTag(TipoCampo.Int, "", "Tipo", 1, 1, Ocorrencia.Obrigatoria, tipoRps));
 
         return ideRps;


### PR DESCRIPTION
Alguns municípios permitem a série alfanumérica.
No manual de orientação ABRASF, o campo série consta como:
Campo: tsSerieRps;  Tipo: C; Descrição: Número de série do RPS; Tamanho: 5