### PR TITLE
Alteração de Header > Authorization concatenação de Insc. Municipal

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/GIAP/GIAPServiceClient100.cs
+++ b/src/OpenAC.Net.NFSe/Providers/GIAP/GIAPServiceClient100.cs
@@ -108,7 +108,7 @@ internal sealed class GIAPServiceClient100 : NFSeHttpServiceClient, IServiceClie
 
     protected override void CustomAuthentication(HttpRequestHeaders requestHeaders)
     {
-        requestHeaders.Add("Authorization", $"{Provider.Configuracoes.PrestadorPadrao.InscricaoMunicipal.ZeroFill(6)}-{(
+        requestHeaders.Add("Authorization", $"{Provider.Configuracoes.PrestadorPadrao.InscricaoMunicipal}-{(
             !string.IsNullOrWhiteSpace(Provider.Configuracoes.WebServices.ChaveAcesso) ? Provider.Configuracoes.WebServices.ChaveAcesso :
             !string.IsNullOrWhiteSpace(Provider.Configuracoes.WebServices.ChavePrivada) ? Provider.Configuracoes.WebServices.ChavePrivada :
             Provider.Configuracoes.WebServices.Usuario

--- a/src/OpenAC.Net.NFSe/Providers/GIAP/GIAPServiceClient200.cs
+++ b/src/OpenAC.Net.NFSe/Providers/GIAP/GIAPServiceClient200.cs
@@ -108,7 +108,7 @@ internal sealed class GIAPServiceClient200 : NFSeHttpServiceClient, IServiceClie
 
     protected override void CustomAuthentication(HttpRequestHeaders requestHeaders)
     {
-        requestHeaders.Add("Authorization", $"{Provider.Configuracoes.PrestadorPadrao.InscricaoMunicipal.ZeroFill(6)}-{(
+        requestHeaders.Add("Authorization", $"{Provider.Configuracoes.PrestadorPadrao.InscricaoMunicipal}-{(
             !string.IsNullOrWhiteSpace(Provider.Configuracoes.WebServices.ChaveAcesso) ? Provider.Configuracoes.WebServices.ChaveAcesso :
             !string.IsNullOrWhiteSpace(Provider.Configuracoes.WebServices.ChavePrivada) ? Provider.Configuracoes.WebServices.ChavePrivada :
             Provider.Configuracoes.WebServices.Usuario


### PR DESCRIPTION
Alteração de Header > Authorization concatenação de IM (inscrição municipal) com o TOKEN (Chave privada) pois estava aplicando ZeroFil(6), no manual informa ser INTEGER, talvez tenhaa feito isso por considerar o exemplo dado no PDF de Manaul de integração que citou 123456-TOKEN, mas o type dele é integer.

#330 

<img width="704" height="601" alt="image" src="https://github.com/user-attachments/assets/c49a059b-115c-44d7-97ea-5be3c107f7c9" />
