### PR TITLE
Incluir alteração dos schemas para GISS e acrescentar novos campos

### DIFF
--- a/src/OpenAC.Net.NFSe/Nota/ValoresServico.cs
+++ b/src/OpenAC.Net.NFSe/Nota/ValoresServico.cs
@@ -74,6 +74,12 @@ public sealed class ValoresServico : GenericClone<ValoresServico>, INotifyProper
     public decimal OutrasRetencoes { get; set; }
 
     public decimal ValTotTributos { get; set; }
+    
+    public decimal? AliquotaTotalEstadual { get; set; }
+    
+    public decimal? AliquotaTotalFederal { get; set; }
+    
+    public decimal? AliquotaTotalMunicipal { get; set; }
 
     public decimal BaseCalculo { get; set; }
 

--- a/src/OpenAC.Net.NFSe/Providers/GISS/ProviderGISS.cs
+++ b/src/OpenAC.Net.NFSe/Providers/GISS/ProviderGISS.cs
@@ -60,7 +60,12 @@ internal class ProviderGISS : ProviderABRASF204
 
         valores.AddChild(AddTag(TipoCampo.De2, "", "DescontoIncondicionado", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.DescontoIncondicionado));
         valores.AddChild(AddTag(TipoCampo.De2, "", "DescontoCondicionado", 1, 15, Ocorrencia.MaiorQueZero, nota.Servico.Valores.DescontoCondicionado));
-
+        
+        
+        var trib = WriteTribRps(nota);
+        if (trib != null)
+            valores.AddChild(trib);
+        
         var IBSCBS = WriteIBSCBSRps(nota);
         
         if(IBSCBS != null)
@@ -68,6 +73,60 @@ internal class ProviderGISS : ProviderABRASF204
         
 
         return valores;
+    }
+
+    protected XElement? WriteTribRps(NotaServico nota)
+    {
+        if (string.IsNullOrWhiteSpace(nota.Servico.Valores.TipoRetencaoPisCofins))
+            return null;
+        
+        var trib = new XElement("trib");
+        var tribFed = WriteTribFedRps(nota);
+        if (tribFed != null)
+            trib.AddChild(tribFed);
+        
+        var tribTot = WriteTribTotRps(nota);
+        if (tribTot != null)
+            trib.AddChild(tribTot);
+
+        return trib;
+    }
+
+    protected XElement WriteTribFedRps(NotaServico nota)
+    {
+        var valores = nota.Servico.Valores;
+        
+        var tribFed = new XElement("tribFed");
+        var piscofins = new XElement("piscofins");
+        piscofins.AddChild(AddTag(TipoCampo.StrNumber, "", "CST", 1, 1, Ocorrencia.Obrigatoria, valores.CstPisCofins));
+        piscofins.AddChild(AddTag(TipoCampo.De2, "", "vBCPisCofins", 1, 1, Ocorrencia.Obrigatoria, valores.BaseCalculo));
+        piscofins.AddChild(AddTag(TipoCampo.De2, "", "pAliqPis", 1, 1, Ocorrencia.Obrigatoria, valores.AliquotaPis));
+        piscofins.AddChild(AddTag(TipoCampo.De2, "", "pAliqCofins", 1, 1, Ocorrencia.Obrigatoria, valores.AliquotaCofins));
+        piscofins.AddChild(AddTag(TipoCampo.De2, "", "vPis", 1, 1, Ocorrencia.Obrigatoria, valores.ValorPis));
+        piscofins.AddChild(AddTag(TipoCampo.De2, "", "vCofins", 1, 1, Ocorrencia.Obrigatoria, valores.ValorCofins));
+        piscofins.AddChild(AddTag(TipoCampo.StrNumber, "", "tpRetPisCofins", 1, 1, Ocorrencia.Obrigatoria, valores.TipoRetencaoPisCofins));
+        
+        tribFed.AddChild(piscofins);
+
+        return tribFed;
+    }
+    
+    protected XElement? WriteTribTotRps(NotaServico nota)
+    {
+        var valores = nota.Servico.Valores;
+        
+        if (!valores.AliquotaTotalEstadual.HasValue &&  !valores.AliquotaTotalEstadual.HasValue && valores.AliquotaTotalMunicipal.HasValue)
+            return null;
+        
+        var totTrib = new XElement("totTrib");
+        var pTotTrib = new XElement("pTotTrib");
+        pTotTrib.AddChild(AddTag(TipoCampo.De2, "", "pTotTribFed", 1, 1, Ocorrencia.Obrigatoria, valores.AliquotaTotalEstadual ?? 0));
+        pTotTrib.AddChild(AddTag(TipoCampo.De2, "", "pTotTribEst", 1, 1, Ocorrencia.Obrigatoria, valores.AliquotaTotalEstadual ?? 0));
+        pTotTrib.AddChild(AddTag(TipoCampo.De2, "", "pTotTribMun", 1, 1, Ocorrencia.Obrigatoria, valores.AliquotaTotalMunicipal ?? 0));
+        
+        totTrib.AddChild(pTotTrib);
+
+        return totTrib;
     }
 
     protected XElement? WriteIBSCBSRps(NotaServico nota)

--- a/src/OpenAC.Net.NFSe/Schemas/GISS/2.04/nfse_v2-04.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/GISS/2.04/nfse_v2-04.xsd
@@ -831,15 +831,31 @@
 	<xsd:simpleType name="TSTipoRetPISCofins">
 		<xsd:annotation>
 			<xsd:documentation>
-        Tipo de retencao do Pis/Cofins:
-        1 - Retido;
-        2 - Não Retido;
+         Tipo de retencao do Pis/Cofins:
+            0 - PIS/COFINS/CSLL Não Retidos;
+			1 - PIS/COFINS Retido;
+			2 - PIS/COFINS Não Retido;
+			3 - PIS/COFINS/CSLL Retidos;
+			4 - PIS/COFINS Retidos, CSLL Não Retido;
+			5 - PIS Retido, COFINS/CSLL Não Retido;
+			6 - COFINS Retido, PIS/CSLL Não Retido;
+			7 - PIS Não Retido, COFINS/CSLL Retidos;
+			8 - PIS/COFINS Não Retidos, CSLL Retido;
+			9 - COFINS Não Retido, PIS/CSLL Retidos;
       </xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
 			<xsd:whiteSpace value="preserve"/>
+			<xsd:enumeration value="0"/>
 			<xsd:enumeration value="1"/>
 			<xsd:enumeration value="2"/>
+			<xsd:enumeration value="3"/>
+			<xsd:enumeration value="4"/>
+			<xsd:enumeration value="5"/>
+			<xsd:enumeration value="6"/>
+			<xsd:enumeration value="7"/>
+			<xsd:enumeration value="8"/>
+			<xsd:enumeration value="9"/>
 		</xsd:restriction>
 	</xsd:simpleType>
 	
@@ -857,16 +873,40 @@
 		<xsd:annotation>
 			<xsd:documentation>
         Código de Situação Tributária do PIS/COFINS (CST):
-        00 - Nenhum;      
-        01 - Operação Tributável com Alíquota Básica;
-        02 - Operação Tributável com Alíquota Diferenciada;
-        03 - Operação Tributável com Alíquota por Unidade de Medida de Produto;
-        04 - Operação Tributável monofásica - Revenda a Alíquota Zero;
-        05 - Operação Tributável por Substituição Tributária;
-        06 - Operação Tributável a Alíquota Zero;
-        07 - Operação Tributável da Contribuição;
-        08 - Operação sem Incidência da Contribuição;
-        09 - Operação com Suspensão da Contribuição;
+        00 - Nenhum; 
+		01 - Operação Tributável com Alíquota Básica;
+		02 - Operação Tributável com Alíquota Diferenciada;
+		03 - Operação Tributável com Alíquota por Unidade de Medida de Produto;
+		04 - Operação Tributável monofásica - Revenda a Alíquota Zero;
+		05 - Operação Tributável por Substituição Tributária;
+		06 - Operação Tributável a Alíquota Zero;
+		07 - Operação Isenta da Contribuição;
+		08 - Operação sem Incidência da Contribuição;
+		09 - Operação com Suspensão da Contribuição;
+		49 - Outras Operações de Saída;
+		50 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Tributada no Mercado Interno;
+		51 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno;
+		52 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita de Exportação;
+		53 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno;
+		54 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas no Mercado Interno e de Exportação;
+		55 - Operação com Direito a Crédito – Vinculada a Receitas Não Tributadas no Mercado Interno e de Exportação;
+		56 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação;
+		60 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno;
+		61 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno;
+		62 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação;
+		63 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno;
+		64 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação;
+		65 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação;
+		66 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação;
+		67 - Crédito Presumido – Outras Operações;
+		70 - Operação de Aquisição sem Direito a Crédito;
+		71 - Operação de Aquisição com Isenção;
+		72 - Operação de Aquisição com Suspensão;
+		73 - Operação de Aquisição a Alíquota Zero;
+		74 - Operação de Aquisição sem Incidência da Contribuição;
+		75 - Operação de Aquisição por Substituição Tributária;
+		98 - Outras Operações de Entrada;
+		99 - Outras Operações;
       </xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
@@ -881,6 +921,30 @@
 			<xsd:enumeration value="07"/>
 			<xsd:enumeration value="08"/>
 			<xsd:enumeration value="09"/>
+			<xsd:enumeration value="49"/>
+			<xsd:enumeration value="50"/>
+			<xsd:enumeration value="51"/>
+			<xsd:enumeration value="52"/>
+			<xsd:enumeration value="53"/>
+			<xsd:enumeration value="54"/>
+			<xsd:enumeration value="55"/>
+			<xsd:enumeration value="56"/>
+			<xsd:enumeration value="60"/>
+			<xsd:enumeration value="61"/>
+			<xsd:enumeration value="62"/>
+			<xsd:enumeration value="63"/>
+			<xsd:enumeration value="64"/>
+			<xsd:enumeration value="65"/>
+			<xsd:enumeration value="66"/>
+			<xsd:enumeration value="67"/>
+			<xsd:enumeration value="70"/>
+			<xsd:enumeration value="71"/>
+			<xsd:enumeration value="72"/>
+			<xsd:enumeration value="73"/>
+			<xsd:enumeration value="74"/>
+			<xsd:enumeration value="75"/>
+			<xsd:enumeration value="98"/>
+			<xsd:enumeration value="99"/>
 		</xsd:restriction>
 	</xsd:simpleType>
 	
@@ -927,12 +991,12 @@
 	<xsd:simpleType name="TSRTCTpOper">
 		<xsd:annotation>
 			<xsd:documentation>
-Tipo de Operação com Entes Governanementais ou outros serviços sobre bens imóveis:
-1 – Fornecimento com pagamento posterior;
-2 –  Recebimento do pagamento com fornecimento já realizado;
-3 – Fornecimento com pagamento já realizado;
-4 – Recebimento do pagamento com fornecimento posterior;
-5 – Fornecimento e recebimento do pagamento concomitantes.
+		Tipo de Operação com Entes Governanementais ou outros serviços sobre bens imóveis:
+		1 – Fornecimento com pagamento posterior;
+		2 –  Recebimento do pagamento com fornecimento já realizado;
+		3 – Fornecimento com pagamento já realizado;
+		4 – Recebimento do pagamento com fornecimento posterior;
+		5 – Fornecimento e recebimento do pagamento concomitantes.
       </xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
@@ -1219,6 +1283,7 @@ Tipo de Operação com Entes Governanementais ou outros serviços sobre bens im�
         4 - Matriz;
         5 - Filial ou sucursal;
         6 - Outro vínculo;
+		9 - Desconhecido (tipo não informado na nota de origem);
       </xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:string">
@@ -1230,6 +1295,7 @@ Tipo de Operação com Entes Governanementais ou outros serviços sobre bens im�
 			<xsd:enumeration value="4"/>
 			<xsd:enumeration value="5"/>
 			<xsd:enumeration value="6"/>
+			<xsd:enumeration value="9"/>
 		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="TSMecAFComExPrest">
@@ -1613,16 +1679,40 @@ Tipo de Operação com Entes Governanementais ou outros serviços sobre bens im�
 				<xsd:annotation>
 					<xsd:documentation>
             Código de Situação Tributária do PIS/COFINS (CST):
-            00 - Nenhum;      
-            01 - Operação Tributável com Alíquota Básica;
-            02 - Operação Tributável com Alíquota Diferenciada;
-            03 - Operação Tributável com Alíquota por Unidade de Medida de Produto;
-            04 - Operação Tributável monofásica - Revenda a Alíquota Zero;
-            05 - Operação Tributável por Substituição Tributária;
-            06 - Operação Tributável a Alíquota Zero;
-            07 - Operação Tributável da Contribuição;
-            08 - Operação sem Incidência da Contribuição;
-            09 - Operação com Suspensão da Contribuição;
+            00 - Nenhum; 
+			01 - Operação Tributável com Alíquota Básica;
+			02 - Operação Tributável com Alíquota Diferenciada;
+			03 - Operação Tributável com Alíquota por Unidade de Medida de Produto;
+			04 - Operação Tributável monofásica - Revenda a Alíquota Zero;
+			05 - Operação Tributável por Substituição Tributária;
+			06 - Operação Tributável a Alíquota Zero;
+			07 - Operação Isenta da Contribuição;
+			08 - Operação sem Incidência da Contribuição;
+			09 - Operação com Suspensão da Contribuição;
+			49 - Outras Operações de Saída;
+			50 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Tributada no Mercado Interno;
+			51 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno;
+			52 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita de Exportação;
+			53 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno;
+			54 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas no Mercado Interno e de Exportação;
+			55 - Operação com Direito a Crédito – Vinculada a Receitas Não Tributadas no Mercado Interno e de Exportação;
+			56 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação;
+			60 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno;
+			61 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno;
+			62 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação;
+			63 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno;
+			64 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação;
+			65 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação;
+			66 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação;
+			67 - Crédito Presumido – Outras Operações;
+			70 - Operação de Aquisição sem Direito a Crédito;
+			71 - Operação de Aquisição com Isenção;
+			72 - Operação de Aquisição com Suspensão;
+			73 - Operação de Aquisição a Alíquota Zero;
+			74 - Operação de Aquisição sem Incidência da Contribuição;
+			75 - Operação de Aquisição por Substituição Tributária;
+			98 - Outras Operações de Entrada;
+			99 - Outras Operações;
           </xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
@@ -1665,8 +1755,16 @@ Tipo de Operação com Entes Governanementais ou outros serviços sobre bens im�
 				<xsd:annotation>
 					<xsd:documentation>
             Tipo de retencao do Pis/Cofins:
-            1 - Retido;
-            2 - Não Retido;
+            0 - PIS/COFINS/CSLL Não Retidos;
+			1 - PIS/COFINS Retido;
+			2 - PIS/COFINS Não Retido;
+			3 - PIS/COFINS/CSLL Retidos;
+			4 - PIS/COFINS Retidos, CSLL Não Retido;
+			5 - PIS Retido, COFINS/CSLL Não Retido;
+			6 - COFINS Retido, PIS/CSLL Não Retido;
+			7 - PIS Não Retido, COFINS/CSLL Retidos;
+			8 - PIS/COFINS Não Retidos, CSLL Retido;
+			9 - COFINS Não Retido, PIS/CSLL Retidos;
           </xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
@@ -2524,6 +2622,7 @@ Tipo de Operação com Entes Governanementais ou outros serviços sobre bens im�
             4 - Matriz;
             5 - Filial ou sucursal;
             6 - Outro vínculo;
+			9 - Desconhecido (tipo não informado na nota de origem);
           </xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>


### PR DESCRIPTION
## Incluir alterações dos schemas para GISS e acrescentar novos campos

### 📌 Resumo
Este PR realiza adequações no provedor **GISS** e em seus schemas, adicionando novos campos tributários e atualizando enumerações conforme regras mais recentes do layout.

Também foi implementada a geração do grupo `<trib>` no RPS quando houver informações tributárias federais configuradas.

---

### ✅ Alterações realizadas

#### `ValoresServico.cs`
Adicionados novos campos opcionais para composição tributária total:

- `AliquotaTotalEstadual`
- `AliquotaTotalFederal`
- `AliquotaTotalMunicipal`

---

#### `ProviderGISS.cs`

##### Inclusão do grupo `<trib>` no XML do RPS
Agora, ao informar retenções PIS/COFINS, será gerado:

```xml
<trib>
   <tribFed>
      <piscofins>...</piscofins>
   </tribFed>
   <totTrib>
      <pTotTrib>...</pTotTrib>
   </totTrib>
</trib>