### PR TITLE
fix: include CMotivo and XMotivo in NFeCidade cancellation request

### DIFF
--- a/src/OpenAC.Net.NFSe/Providers/NFeCidades/ProviderNFeCidades.cs
+++ b/src/OpenAC.Net.NFSe/Providers/NFeCidades/ProviderNFeCidades.cs
@@ -275,6 +275,34 @@ internal sealed class ProviderNFeCidades : ProviderABRASF201
         throw new NotImplementedException($"O provedor [{Name}] não implementa o método [{nameof(Enviar)}], utilize o método [{nameof(EnviarSincrono)}]");
     }
 
+    protected override void PrepararCancelarNFSe(RetornoCancelar retornoWebservice)
+{
+    if (retornoWebservice.NumeroNFSe.IsEmpty() || retornoWebservice.CodigoCancelamento.IsEmpty())
+    {
+        retornoWebservice.Erros.Add(new EventoRetorno { Codigo = "0", Descricao = "Número da NFSe/Codigo de cancelamento não informado para cancelamento." });
+        return;
+    }
+
+    var loteBuilder = new StringBuilder();
+    loteBuilder.Append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+    loteBuilder.Append($"<CancelarNfseEnvio {GetNamespace()}>");
+    loteBuilder.Append("<Pedido>");
+    loteBuilder.Append($"<InfPedidoCancelamento Id=\"N{retornoWebservice.NumeroNFSe}\">");
+    loteBuilder.Append("<IdentificacaoNfse>");
+    loteBuilder.Append($"<Numero>{retornoWebservice.NumeroNFSe}</Numero>");
+    loteBuilder.Append($"<CpfCnpj><Cnpj>{Configuracoes.PrestadorPadrao.CpfCnpj.ZeroFill(14)}</Cnpj></CpfCnpj>");
+    loteBuilder.Append($"<InscricaoMunicipal>{Configuracoes.PrestadorPadrao.InscricaoMunicipal}</InscricaoMunicipal>");
+    loteBuilder.Append($"<CodigoMunicipio>{Configuracoes.PrestadorPadrao.Endereco.CodigoMunicipio}</CodigoMunicipio>");
+    loteBuilder.Append("</IdentificacaoNfse>");
+    loteBuilder.Append($"<CodigoCancelamento>{retornoWebservice.CodigoCancelamento}</CodigoCancelamento>");
+    loteBuilder.Append($"<CMotivo>{retornoWebservice.CodigoCancelamento}</CMotivo>");
+    loteBuilder.Append($"<XMotivo>{retornoWebservice.Motivo}</CMotivo>");
+    loteBuilder.Append("</InfPedidoCancelamento>");
+    loteBuilder.Append("</Pedido>");
+    loteBuilder.Append("</CancelarNfseEnvio>");
+    retornoWebservice.XmlEnvio = loteBuilder.ToString();
+}
+
     protected override IServiceClient GetClient(TipoUrl tipo) => new NFeCidadesServiceClient(this, tipo);
 
     #endregion Protected Methods


### PR DESCRIPTION
#372

Descrição:

Ao realizar o cancelamento de uma NFS-e através da integração com o NFeCidade, o processo não é concluído com sucesso devido à ausência dos campos obrigatórios CMotivo e XMotivo na requisição enviada.

Problema identificado:

O cancelamento retorna erro no provedor NFeCidade.
Foi verificado que os campos CMotivo (código do motivo) e XMotivo (descrição do motivo) não estão sendo enviados na solicitação de cancelamento.
Esses campos são obrigatórios para que o cancelamento seja processado pelo provedor.

Solicitação:

Ajustar a geração da requisição de cancelamento para incluir os campos CMotivo e XMotivo conforme especificação do NFeCidade.
Garantir que os valores sejam preenchidos corretamente antes do envio.
Validar o cancelamento em ambiente de homologação e produção após a correção.
 