### PR TITLE
Geração do grupo IBS/CBS na Tiplan e layout 2 de São Paulo

### DIFF
--- a/src/OpenAC.Net.NFSe.Test/OpenAC.Net.NFSe.Test.csproj
+++ b/src/OpenAC.Net.NFSe.Test/OpenAC.Net.NFSe.Test.csproj
@@ -11,8 +11,9 @@
 
     <ItemGroup>
         <PackageReference Include="OpenAC.Net.DFe.Core" Version="1.6.0.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/OpenAC.Net.NFSe.Test/TestProviderISSSaoPaulo.cs
+++ b/src/OpenAC.Net.NFSe.Test/TestProviderISSSaoPaulo.cs
@@ -1,0 +1,372 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.Schema;
+using OpenAC.Net.DFe.Core;
+using OpenAC.Net.DFe.Core.Serializer;
+using OpenAC.Net.NFSe.Commom.Types;
+using OpenAC.Net.NFSe.Configuracao;
+using OpenAC.Net.NFSe.Nota;
+using OpenAC.Net.NFSe.Providers;
+using Xunit;
+
+namespace OpenAC.Net.NFSe.Test;
+
+public class TestProviderISSSaoPaulo
+{
+    private const string EndpointLayouts1E2 =
+        "https://nfews.prefeitura.sp.gov.br/lotenfe.asmx?WSDL";
+
+    private const string CadeiaOficial =
+        "123456789012RTNT 00000000000120260101TNN00000000205000000000000050000002658100013167474254209999999000106S";
+
+    private const string AssinaturaEsperada =
+        "dZCSPerLU4J6T3VDd8iJ3v2wiVjdSsyptQ+Zu2bn0XAazU+X6lSSEfKFo41WXMX9kFkAkKIQKRgbSmoLXnkX/OdHCL9RnrTDLmeTbdB3iYIxhgmCkyuqsM9mSIv2TH2HPBXSuLAJUoMJUdBxOeFjuSgF3b8FKvkeGeOkNo+luFvnFHYN3On/TT528vzDSxeYcYF6NNHb1aDAVaIm9RpMo+7QFhbGMbAjMAJy4o5LUtKS1+bJaLJPvuq53jZOHWFw66Ah7U5t2i7VYDCrr6tTYmiH6bxFcG8zK97Up3Wlbd6ssh8rPdiou14HlnNZCsTuvmploRJNhEzTMe7Qed9Rbw==";
+
+    [Fact]
+    public void LayoutPadraoContinuaSendoLayout1()
+    {
+        Assert.Equal(LayoutISSSaoPaulo.Layout1, new ConfigNFSe().WebServices.LayoutISSSaoPaulo);
+    }
+
+    [Fact]
+    public void SaoPauloUsaEndpointQueAceitaLayouts1E2()
+    {
+        var municipio = Assert.Single(ProviderManager.Municipios, x => x.Codigo == 3550308);
+
+        Assert.Equal(EndpointLayouts1E2, municipio.UrlHomologacao[TipoUrl.Enviar]);
+        Assert.Equal(EndpointLayouts1E2, municipio.UrlProducao[TipoUrl.Enviar]);
+        Assert.Equal(EndpointLayouts1E2, municipio.UrlProducao[TipoUrl.CancelarNFSe]);
+        Assert.Equal(EndpointLayouts1E2, municipio.UrlProducao[TipoUrl.ConsultarNFSe]);
+        Assert.Equal(EndpointLayouts1E2, municipio.UrlProducao[TipoUrl.ConsultarNFSeRps]);
+        Assert.Equal(EndpointLayouts1E2, municipio.UrlProducao[TipoUrl.ConsultarLoteRps]);
+        Assert.Equal(EndpointLayouts1E2, municipio.UrlProducao[TipoUrl.ConsultarSituacao]);
+    }
+
+    [Fact]
+    public void Layout1ExplicitoProduzOMesmoXmlDoPadrao()
+    {
+        using var certificado = CriarCertificado();
+        var pfx = certificado.Export(X509ContentType.Pfx, "teste");
+        var configuracaoPadrao = CriarConfiguracao(pfx);
+        var configuracaoExplicita = CriarConfiguracao(pfx);
+        configuracaoExplicita.WebServices.LayoutISSSaoPaulo = LayoutISSSaoPaulo.Layout1;
+
+        var xmlPadrao = CriarNotaLayout1(configuracaoPadrao).GetXml();
+        var xmlExplicito = CriarNotaLayout1(configuracaoExplicita).GetXml();
+
+        Assert.Equal(xmlPadrao, xmlExplicito);
+        Assert.Contains("<ValorServicos>100.00</ValorServicos>", xmlPadrao);
+        Assert.DoesNotContain("<IBSCBS>", xmlPadrao);
+    }
+
+    [Fact]
+    public void SeletorDeLayout2AcionaOSerializerNovo()
+    {
+        using var certificado = CriarCertificado();
+        var config = CriarConfiguracao(certificado.Export(X509ContentType.Pfx, "teste"));
+        config.WebServices.LayoutISSSaoPaulo = LayoutISSSaoPaulo.Layout2;
+
+        var xml = CriarNotaExemploOficial(config).GetXml();
+
+        Assert.Contains("<ValorFinalCobrado>20500.00</ValorFinalCobrado>", xml);
+        Assert.Contains("<IBSCBS>", xml);
+        Assert.DoesNotContain("<ValorServicos>", xml);
+    }
+
+    [Fact]
+    public void CadeiaOficialTemConteudoPreenchimentosETamanhoEsperados()
+    {
+        var cadeia = ISSSaoPauloLayout2.MontarCadeiaAssinatura(CriarNotaExemploOficial());
+
+        Assert.Equal(CadeiaOficial, cadeia);
+        Assert.Equal(106, cadeia.Length);
+        Assert.Equal("123456789012", cadeia[..12]);
+        Assert.Equal("RTNT ", cadeia.Substring(12, 5));
+        Assert.Equal("000000000001", cadeia.Substring(17, 12));
+        Assert.Equal("20260101", cadeia.Substring(29, 8));
+        Assert.Equal("000000002050000", cadeia.Substring(40, 15));
+        Assert.Equal("000000000500000", cadeia.Substring(55, 15));
+        Assert.Equal("02658", cadeia.Substring(70, 5));
+    }
+
+    [Fact]
+    public void Sha1DaCadeiaOficialConfere()
+    {
+        var hash = SHA1.HashData(Encoding.ASCII.GetBytes(CadeiaOficial));
+
+        Assert.Equal("D30FFC47832BB2CD5397ACBA4393AE00565608CD", Convert.ToHexString(hash));
+    }
+
+    [Fact]
+    public void AssinaturaRsaSha1DoExemploEhDeterministica()
+    {
+        using var rsa = CriarRsa();
+
+        var assinatura = ISSSaoPauloLayout2.AssinarRps(CriarNotaExemploOficial(), rsa);
+
+        Assert.Equal(AssinaturaEsperada, assinatura);
+        Assert.True(rsa.VerifyData(Encoding.ASCII.GetBytes(CadeiaOficial),
+            Convert.FromBase64String(assinatura), HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1));
+    }
+
+    public static IEnumerable<object[]> RetencoesPisCofins()
+    {
+        yield return new object[] { false, false, false, 0 };
+        yield return new object[] { true, true, true, 3 };
+        yield return new object[] { true, true, false, 4 };
+        yield return new object[] { true, false, false, 5 };
+        yield return new object[] { false, true, false, 6 };
+        yield return new object[] { false, true, true, 7 };
+        yield return new object[] { false, false, true, 8 };
+        yield return new object[] { true, false, true, 9 };
+    }
+
+    [Theory]
+    [MemberData(nameof(RetencoesPisCofins))]
+    public void RetencaoPisCofinsSegueAsOitoCombinacoesDoLayout2(bool pis, bool cofins, bool csll,
+        int esperado)
+    {
+        var valores = new NotaServico(new ConfigNFSe()).Servico.Valores;
+        valores.ValorPis = pis ? 1 : 0;
+        valores.ValorCofins = cofins ? 1 : 0;
+        valores.ValorCsll = csll ? 1 : 0;
+
+        Assert.Equal(esperado, ISSSaoPauloLayout2.ObterRetencaoPisCofins(valores));
+    }
+
+    [Fact]
+    public void XmlLayout2SegueOrdemEscolhasEGrupoMinimo()
+    {
+        using var certificado = CriarCertificado();
+        var nota = CriarNotaExemploOficial();
+
+        var xml = XDocument.Parse(ISSSaoPauloLayout2.WriteXmlRps(nota, certificado));
+        var rps = xml.Root!;
+        var nomes = rps.Elements().Select(x => x.Name.LocalName).ToArray();
+
+        Assert.True(Array.IndexOf(nomes, "ValorFinalCobrado") < Array.IndexOf(nomes, "ValorIPI"));
+        Assert.True(Array.IndexOf(nomes, "ValorIPI") < Array.IndexOf(nomes, "ExigibilidadeSuspensa"));
+        Assert.True(Array.IndexOf(nomes, "ExigibilidadeSuspensa") < Array.IndexOf(nomes, "NBS"));
+        Assert.True(Array.IndexOf(nomes, "NBS") < Array.IndexOf(nomes, "cLocPrestacao"));
+        Assert.True(Array.IndexOf(nomes, "cLocPrestacao") < Array.IndexOf(nomes, "IBSCBS"));
+        Assert.DoesNotContain("ValorInicialCobrado", nomes);
+        Assert.DoesNotContain("ValorServicos", nomes);
+        Assert.Equal("20500.00", rps.Element("ValorFinalCobrado")?.Value);
+        Assert.Equal("118054000", rps.Element("NBS")?.Value);
+        Assert.Equal("3550308", rps.Element("cLocPrestacao")?.Value);
+
+        var ibsCbs = rps.Element("IBSCBS")!;
+        Assert.Equal(new[] { "finNFSe", "indFinal", "cIndOp", "indDest", "valores" },
+            ibsCbs.Elements().Select(x => x.Name.LocalName));
+        Assert.Equal("200001", ibsCbs.Element("valores")?.Element("trib")?.Element("gIBSCBS")
+            ?.Element("cClassTrib")?.Value);
+    }
+
+    [Fact]
+    public void ExatamenteUmValorCobradoEhObrigatorio()
+    {
+        var nota = CriarNotaExemploOficial();
+        nota.Servico.Valores.ValorInicialCobrado = 100;
+
+        var erro = Assert.ThrowsAny<Exception>(() => ISSSaoPauloLayout2.MontarCadeiaAssinatura(nota));
+
+        Assert.Contains("exatamente um", erro.Message);
+    }
+
+    [Fact]
+    public void LoteLayout2RecusaMaisDeCinquentaRpsAntesDaTransmissao()
+    {
+        var config = new ConfigNFSe();
+        config.WebServices.CodigoMunicipio = 3550308;
+        config.WebServices.LayoutISSSaoPaulo = LayoutISSSaoPaulo.Layout2;
+        var openNFSe = new OpenNFSe(config);
+        for (var i = 0; i < 51; i++)
+            openNFSe.NotasServico.AddNew();
+
+        var erro = Assert.ThrowsAny<Exception>(() => openNFSe.Enviar(1));
+
+        Assert.Contains("máximo de 50 RPS", erro.Message);
+    }
+
+    [Fact]
+    public void XmlLayout2ValidaNoXsdDistribuido()
+    {
+        using var certificado = CriarCertificado();
+        var rps = XElement.Parse(ISSSaoPauloLayout2.WriteXmlRps(CriarNotaExemploOficial(),
+            certificado, false, false));
+        XNamespace ns = "http://www.prefeitura.sp.gov.br/nfe";
+        var raiz = new XElement(ns + "PedidoEnvioRPS",
+            new XElement("Cabecalho",
+                new XAttribute("Versao", 2),
+                new XElement("CPFCNPJRemetente",
+                    new XElement("CNPJ", "12345678000190"))),
+            rps);
+        var xml = new XDocument(new XDeclaration("1.0", "UTF-8", null), raiz)
+            .ToString(SaveOptions.DisableFormatting);
+        xml = XmlSigning.AssinarXml(xml, "PedidoEnvioRPS", "", certificado);
+
+        ValidarXml(xml, ObterSchema("PedidoEnvioRPS_v02.xsd"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RetornosV01EV02PreservamIdentificadoresEOriginal(bool layout2)
+    {
+        var config = new ConfigNFSe();
+        config.WebServices.CodigoMunicipio = 3550308;
+        config.WebServices.LayoutISSSaoPaulo = layout2
+            ? LayoutISSSaoPaulo.Layout2
+            : LayoutISSSaoPaulo.Layout1;
+        var openNFSe = new OpenNFSe(config);
+        var complemento = layout2
+            ? "<RetornoComplementarIBSCBS><ValorBaseCalculo>100.00</ValorBaseCalculo></RetornoComplementarIBSCBS>"
+            : string.Empty;
+        var camposV2 = layout2
+            ? "<ChaveNotaNacional>35503081234567890000000000000000000000000000000000</ChaveNotaNacional>"
+            : string.Empty;
+        var dataFato = layout2
+            ? "<DataFatoGeradorNFe>2026-08-01T10:30:00</DataFatoGeradorNFe>"
+            : string.Empty;
+        var xml = "<NFe><ChaveNFe><InscricaoPrestador>123456789012</InscricaoPrestador>" +
+                  "<NumeroNFe>987</NumeroNFe><CodigoVerificacao>ABC123</CodigoVerificacao>" +
+                  camposV2 + "</ChaveNFe><DataEmissaoNFe>2026-08-01T10:31:00</DataEmissaoNFe>" +
+                  dataFato + "<NumeroLote>42</NumeroLote>" + complemento + "</NFe>";
+
+        var nota = openNFSe.NotasServico.Load(xml);
+
+        Assert.Equal("987", nota.IdentificacaoNFSe.Numero);
+        Assert.Equal("ABC123", nota.IdentificacaoNFSe.Chave);
+        Assert.Equal(42, nota.NumeroLote);
+        Assert.Equal(xml, nota.XmlOriginal);
+        if (layout2)
+        {
+            Assert.Equal(new DateTime(2026, 8, 1, 10, 30, 0), nota.IdentificacaoNFSe.DataFatoGerador);
+            Assert.StartsWith("3550308", nota.IdentificacaoNFSe.ChaveNotaNacional);
+            Assert.Equal(complemento, nota.XmlRetornoComplementarIBSCBS);
+        }
+        else
+        {
+            Assert.Null(nota.IdentificacaoNFSe.DataFatoGerador);
+            Assert.True(string.IsNullOrEmpty(nota.IdentificacaoNFSe.ChaveNotaNacional));
+            Assert.True(string.IsNullOrEmpty(nota.XmlRetornoComplementarIBSCBS));
+        }
+    }
+
+    private static ConfigNFSe CriarConfiguracao(byte[] pfx)
+    {
+        var config = new ConfigNFSe();
+        config.Geral.Salvar = false;
+        config.Arquivos.Salvar = false;
+        config.WebServices.CodigoMunicipio = 3550308;
+        config.Certificados.CertificadoBytes = pfx;
+        config.Certificados.Senha = "teste";
+        config.PrestadorPadrao.CpfCnpj = "12345678000190";
+        config.PrestadorPadrao.InscricaoMunicipal = "12345678";
+        return config;
+    }
+
+    private static NotaServico CriarNotaLayout1(ConfigNFSe config)
+    {
+        var nota = new OpenNFSe(config).NotasServico.AddNew();
+        nota.IdentificacaoRps.Numero = "1";
+        nota.IdentificacaoRps.Serie = "A";
+        nota.IdentificacaoRps.Tipo = TipoRps.RPS;
+        nota.IdentificacaoRps.DataEmissao = new DateTime(2026, 7, 31);
+        nota.Situacao = SituacaoNFSeRps.Normal;
+        nota.TipoTributacao = TipoTributacao.Tributavel;
+        nota.Servico.Valores.ValorServicos = 100;
+        nota.Servico.Valores.Aliquota = 2;
+        nota.Servico.ItemListaServico = "2658";
+        nota.Servico.Discriminacao = "Servico de teste";
+        nota.Tomador.CpfCnpj = "13167474254";
+        return nota;
+    }
+
+    private static NotaServico CriarNotaExemploOficial(ConfigNFSe? config = null)
+    {
+        var nota = new NotaServico(config ?? new ConfigNFSe());
+        nota.Prestador.InscricaoMunicipal = "123456789012";
+        nota.IdentificacaoRps.Serie = "RTNT";
+        nota.IdentificacaoRps.Numero = "1";
+        nota.IdentificacaoRps.Tipo = TipoRps.RPS;
+        nota.IdentificacaoRps.DataEmissao = new DateTime(2026, 1, 1);
+        nota.Situacao = SituacaoNFSeRps.Normal;
+        nota.TipoTributacao = TipoTributacao.Tributavel;
+        nota.Servico.Valores.IssRetido = SituacaoTributaria.Normal;
+        nota.Servico.Valores.ValorFinalCobrado = 20500;
+        nota.Servico.Valores.ValorDeducoes = 5000;
+        nota.Servico.Valores.ValorIpi = 0;
+        nota.Servico.Valores.ExigibilidadeSuspensa = false;
+        nota.Servico.Valores.Aliquota = 2;
+        nota.Servico.ItemListaServico = "2658";
+        nota.Servico.CodigoNbs = "118054000";
+        nota.Servico.Discriminacao = "Servico de teste sem dados reais";
+        nota.Servico.CodigoMunicipio = 3550308;
+        nota.Servico.MunicipioIncidencia = 3550308;
+        nota.Tomador.CpfCnpj = "13167474254";
+        nota.Intermediario.CpfCnpj = "09999999000106";
+        nota.Intermediario.IssRetido = SituacaoTributaria.Retencao;
+        nota.Servico.Valores.IBSCBS = new InfoIBSCBS
+        {
+            FinalidadeNFSe = "0",
+            IndicadorFinal = "1",
+            CodigoIndicadorOperacao = "123456",
+            IndicadorDestinatario = "1"
+        };
+        nota.Servico.Valores.IBSCBS.Valores.Tributos.SituacaoClassificacao
+            .CodigoClassificacaoTributaria = "200001";
+        return nota;
+    }
+
+    private static X509Certificate2 CriarCertificado()
+    {
+        using var rsa = CriarRsa();
+        var request = new CertificateRequest("CN=OpenAC NFSe Teste", rsa, HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+    }
+
+    private static RSA CriarRsa()
+    {
+        var rsa = RSA.Create();
+        rsa.ImportParameters(new RSAParameters
+        {
+            Modulus = Convert.FromBase64String("6FgMyOlnY2mN8/3SL12k7gmDO7JM7PhFy8mCUVg5kN5IOIra6gEKMSoUIxWDg7Cn5fClD5iF82CUTfadRj8433i3snFJ0SRjCD2nrLVITdyDMzbitwdG2Dqbp7604C+evobXTrn9d2e37EoRiTOqPuRNC/PhfcDzt5EbM3hxd1wWS0UJAnBcCK1qxnk213WgR0dHgXfZsOYtRuGsgWojeR0NWGqDqIM357DvGhQm5S69ob38Wj6n4Eem6fX/l1m3R3d0MyIDWWTBi7kzFJOxfaahYJO3OLTk0g1dtvGKCV6DoFGXiU4xywjEUfhUs5Dw07dK6F23tueleOoHdh8Aew=="),
+            Exponent = Convert.FromBase64String("AQAB"),
+            D = Convert.FromBase64String("DNZYln025io92p5Kj61n4HMMGi9Gys0I5jKTDbWHMLbnXKBnagh2rLK7fBjDNHJ9RFogdJUjyYerigc3N1tk5AwCckyKHJEbG6h0bDlz7kFhymGc8ynmwymx0fnaeoyHA9XlbYcfNwq3Acox39fH70Oj8iYebllL3feZfiWId2S3KoAhhtiUKu69+Eo8/U4RYZLLkXuUcOqktEPe01QeVluwdLO09r71THV/A1FOOMT3aW3S+1J6M0QgIK5X1l+GxAYwBXmkSP4znpvBaEeMDghLOoAXA0CN1MWt7Ve0TN/AD447LwtjGskxEYBNYslpGGV3VYoSCkvUdhcDU8UAEQ=="),
+            P = Convert.FromBase64String("/TBS++rjM6aAb36VrpbX4ey/qxIJX7S6ApMw7QbcMTv22fYK8VUcjH4zSYx//mY8Mwu2y4dGmld8d//Zdk+AOC36hBJ8fd1PGvmVPudUXAHuvjPBWGJDhvrJUUE0psn+LNl1JeH6B/fM6azwX+NiM69Vii/vHLsZrvd9EYOuTGk="),
+            Q = Convert.FromBase64String("6ux5uFNs/SaDK5DVzAOZYeez28L8qC/Y6RmY6oUpyjCQHtqezML4F/nNJjzjldyKCS3xYvBq+NZ38WuZJDOaorFaJqj6PERE1Yc58KOrwxiS9tgIELEAzu+M0aMU7s0fp347n3Jn4LXfdg/mvGOsqVwxsl5DOeNsNCkW5BNc2UM="),
+            DP = Convert.FromBase64String("YPb/4QDdEKvkpk6ZbqrQdPLhmNeohWHGlzPd2fj1nVl0uZbULAbHjzrJ05IedsSaq4YB9MKTFIsK3T47/2aFGX7qYWhfCykVoaQSN2wKz83hrDBQDNRdPjWPojHRw0q6sFx71A1OX3zUmm2kBWUk99xfazPeZGd3d53K5UlEGHk="),
+            DQ = Convert.FromBase64String("HNsjMGL+9jFu10EZIdAnXQFK9GmFA1utNySvxc7JjU5dxYxxCRHBy6AhdNrx0YyfX/VGuzJw0VP2s67Vxr6X9ff27NzAr/pqwhe0JDzWckZodu2eP/6d7M077NwtTA/iHX7B8BnrbIyqgCP/4ZAUu1DZweEWPNwUhGuvpiBCvWU="),
+            InverseQ = Convert.FromBase64String("zn2buxoHQvWUUnJgrUTuVHn3Eznay/HNWs52yf4MeEhUGmxjHx159wcoNiOQc7FJePFT98KoSJ99HOKhKwhqu+sDk3E66LGwIItZOYZyl5/kJNY651/w8qhAwSg57FUfGK8BsR2qkiFe6607LDH/GTYAfPI2Ulu5IIMmmPIo+os=")
+        });
+        return rsa;
+    }
+
+    private static string ObterSchema(string nome)
+    {
+        return Path.Combine(AppContext.BaseDirectory, "Schemas", "ISSSaoPaulo", "1.00", nome);
+    }
+
+    private static void ValidarXml(string xml, string schema)
+    {
+        var erros = new List<string>();
+        var settings = new XmlReaderSettings
+        {
+            ValidationType = ValidationType.Schema
+        };
+        settings.Schemas.XmlResolver = new XmlUrlResolver();
+        settings.Schemas.Add("http://www.prefeitura.sp.gov.br/nfe", schema);
+        settings.ValidationEventHandler += (_, args) => erros.Add(args.Message);
+        using var reader = XmlReader.Create(new StringReader(xml), settings);
+        while (reader.Read())
+        {
+        }
+
+        Assert.True(erros.Count == 0, string.Join(Environment.NewLine, erros));
+    }
+}

--- a/src/OpenAC.Net.NFSe.Test/TestProviderTiplan203.cs
+++ b/src/OpenAC.Net.NFSe.Test/TestProviderTiplan203.cs
@@ -1,0 +1,168 @@
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.Schema;
+using OpenAC.Net.NFSe.Configuracao;
+using OpenAC.Net.NFSe.Nota;
+using Xunit;
+
+namespace OpenAC.Net.NFSe.Test;
+
+public class TestProviderTiplan203
+{
+    [Fact]
+    public void CamposNulosPreservamXmlLegado()
+    {
+        var nota = CriarNota();
+        var xmlSemGrupo = nota.GetXml();
+
+        nota.Servico.Valores.IBSCBS = new InfoIBSCBS();
+        var xmlComObjetoVazio = nota.GetXml();
+
+        Assert.Equal(xmlSemGrupo, xmlComObjetoVazio);
+        Assert.DoesNotContain("<IBSCBS>", xmlSemGrupo);
+        Assert.Contains("<CodigoNbs>118054000</CodigoNbs>", xmlSemGrupo);
+    }
+
+    [Fact]
+    public void GrupoCompletoEhGeradoNaOrdemOficial()
+    {
+        var nota = CriarNota(3303302);
+        PreencherGrupoCompleto(nota);
+
+        var xml = XDocument.Parse(nota.GetXml());
+        var grupo = xml.Descendants().Single(x => x.Name.LocalName == "IBSCBS");
+        var nomes = grupo.Elements().Select(x => x.Name.LocalName).ToArray();
+        var valoresTributos = grupo.Elements().Single(x => x.Name.LocalName == "ValoresTributos");
+
+        Assert.Equal(new[] { "OperacaoUsoConsumoPessoal", "Operacao", "ValoresTributos" }, nomes);
+        Assert.Equal("1", grupo.Elements().Single(x => x.Name.LocalName == "OperacaoUsoConsumoPessoal").Value);
+        Assert.Equal("123456", grupo.Elements().Single(x => x.Name.LocalName == "Operacao").Value);
+        Assert.Equal("200", valoresTributos.Elements().Single(x => x.Name.LocalName == "SituacaoTributaria").Value);
+        Assert.Equal("200001",
+            valoresTributos.Elements().Single(x => x.Name.LocalName == "ClassificacaoTributaria").Value);
+    }
+
+    public static IEnumerable<object?[]> ConfiguracoesParciais()
+    {
+        yield return new object?[] { "1", null, null };
+        yield return new object?[] { null, "123456", null };
+        yield return new object?[] { null, null, "200001" };
+        yield return new object?[] { "1", "123456", null };
+        yield return new object?[] { "1", null, "200001" };
+        yield return new object?[] { null, "123456", "200001" };
+    }
+
+    [Theory]
+    [MemberData(nameof(ConfiguracoesParciais))]
+    public void ConfiguracaoParcialEhRecusada(string? indicadorFinal, string? operacao, string? classificacao)
+    {
+        var nota = CriarNota();
+        nota.Servico.Valores.IBSCBS = new InfoIBSCBS
+        {
+            IndicadorFinal = indicadorFinal,
+            CodigoIndicadorOperacao = operacao
+        };
+        nota.Servico.Valores.IBSCBS.Valores.Tributos.SituacaoClassificacao.CodigoClassificacaoTributaria =
+            classificacao;
+
+        var erro = Assert.ThrowsAny<Exception>(() => nota.GetXml());
+        Assert.Contains("IBS/CBS da Tiplan", erro.Message);
+    }
+
+    [Fact]
+    public void SituacaoInformadaDiferenteDaClassificacaoEhRecusada()
+    {
+        var nota = CriarNota();
+        PreencherGrupoCompleto(nota);
+        nota.Servico.Valores.IBSCBS!.Valores.Tributos.SituacaoClassificacao.CodigoSituacaoTributaria = "999";
+
+        var erro = Assert.ThrowsAny<Exception>(() => nota.GetXml());
+        Assert.Contains("três primeiros dígitos", erro.Message);
+    }
+
+    [Fact]
+    public void XmlCompletoValidaNoXsdDistribuido()
+    {
+        var nota = CriarNota();
+        PreencherGrupoCompleto(nota);
+        ValidarXml(nota.GetXml(), ObterSchema());
+    }
+
+    private static NotaServico CriarNota(int codigoMunicipio = 3501608)
+    {
+        var openNFSe = new OpenNFSe(new ConfigNFSe());
+        openNFSe.Configuracoes.Geral.Salvar = false;
+        openNFSe.Configuracoes.Arquivos.Salvar = false;
+        openNFSe.Configuracoes.WebServices.CodigoMunicipio = codigoMunicipio;
+        openNFSe.Configuracoes.PrestadorPadrao.CpfCnpj = "12345678000190";
+        openNFSe.Configuracoes.PrestadorPadrao.InscricaoMunicipal = "12345";
+
+        var nota = openNFSe.NotasServico.AddNew();
+        nota.IdentificacaoRps.Numero = "1";
+        nota.IdentificacaoRps.Serie = "A";
+        nota.IdentificacaoRps.Tipo = TipoRps.RPS;
+        nota.IdentificacaoRps.DataEmissao = new DateTime(2026, 8, 1);
+        nota.Competencia = new DateTime(2026, 8, 1);
+        nota.Situacao = SituacaoNFSeRps.Normal;
+        nota.RegimeEspecialTributacao = RegimeEspecialTributacao.Nenhum;
+        nota.OptanteSimplesNacional = NFSeSimNao.Nao;
+        nota.IncentivadorCultural = NFSeSimNao.Nao;
+
+        nota.Prestador.CpfCnpj = "12345678000190";
+        nota.Prestador.InscricaoMunicipal = "12345";
+        nota.Servico.Valores.ValorServicos = 100M;
+        nota.Servico.Valores.BaseCalculo = 100M;
+        nota.Servico.Valores.Aliquota = 2M;
+        nota.Servico.Valores.IssRetido = SituacaoTributaria.Normal;
+        nota.Servico.ItemListaServico = "0107";
+        nota.Servico.CodigoNbs = "118054000";
+        nota.Servico.Discriminacao = "Serviço de teste sem dados reais";
+        nota.Servico.CodigoMunicipio = codigoMunicipio;
+        nota.Servico.MunicipioIncidencia = codigoMunicipio;
+        nota.Servico.ExigibilidadeIss = ExigibilidadeIss.Exigivel;
+
+        nota.Tomador.CpfCnpj = "12345678901";
+        nota.Tomador.RazaoSocial = "Tomador de Teste";
+        nota.Tomador.Endereco.Logradouro = "Rua de Teste";
+        nota.Tomador.Endereco.Numero = "1";
+        nota.Tomador.Endereco.Bairro = "Centro";
+        nota.Tomador.Endereco.CodigoMunicipio = codigoMunicipio;
+        nota.Tomador.Endereco.Uf = "SP";
+        nota.Tomador.Endereco.Cep = "13465000";
+        return nota;
+    }
+
+    private static void PreencherGrupoCompleto(NotaServico nota)
+    {
+        nota.Servico.Valores.IBSCBS = new InfoIBSCBS
+        {
+            IndicadorFinal = "1",
+            CodigoIndicadorOperacao = "123456"
+        };
+        nota.Servico.Valores.IBSCBS.Valores.Tributos.SituacaoClassificacao.CodigoClassificacaoTributaria =
+            "200001";
+    }
+
+    private static string ObterSchema()
+    {
+        return Path.Combine(AppContext.BaseDirectory, "Schemas", "Tiplan", "2.03", "nfse.xsd");
+    }
+
+    private static void ValidarXml(string xml, string schema)
+    {
+        var erros = new List<string>();
+        var settings = new XmlReaderSettings
+        {
+            ValidationType = ValidationType.Schema
+        };
+        settings.Schemas.XmlResolver = new XmlUrlResolver();
+        settings.Schemas.Add(null, schema);
+        settings.ValidationEventHandler += (_, args) => erros.Add(args.Message);
+        using var reader = XmlReader.Create(new StringReader(xml), settings);
+        while (reader.Read())
+        {
+        }
+
+        Assert.True(erros.Count == 0, string.Join(Environment.NewLine, erros));
+    }
+}

--- a/src/OpenAC.Net.NFSe/Configuracao/ConfigWebServicesNFSe.cs
+++ b/src/OpenAC.Net.NFSe/Configuracao/ConfigWebServicesNFSe.cs
@@ -73,6 +73,8 @@ public sealed class ConfigWebServicesNFSe : DFeWebserviceConfigBase
 
     public NFSeProvider Provider { get; private set; } = NFSeProvider.Nenhum;
 
+    public LayoutISSSaoPaulo LayoutISSSaoPaulo { get; set; }
+
     public string Usuario { get; set; }
 
     public string Senha { get; set; }

--- a/src/OpenAC.Net.NFSe/Configuracao/LayoutISSSaoPaulo.cs
+++ b/src/OpenAC.Net.NFSe/Configuracao/LayoutISSSaoPaulo.cs
@@ -1,0 +1,7 @@
+namespace OpenAC.Net.NFSe.Configuracao;
+
+public enum LayoutISSSaoPaulo
+{
+    Layout1,
+    Layout2
+}

--- a/src/OpenAC.Net.NFSe/Nota/IdeNFSe.cs
+++ b/src/OpenAC.Net.NFSe/Nota/IdeNFSe.cs
@@ -60,10 +60,14 @@ public sealed class IdeNFSe : GenericClone<IdeNFSe>, INotifyPropertyChanged
     public string Numero { get; set; }
 
     public string Chave { get; set; }
+
+    public string ChaveNotaNacional { get; set; }
     
     public string Serie { get; set; }
 
     public DateTime DataEmissao { get; set; }
+
+    public DateTime? DataFatoGerador { get; set; }
 
     public string ModeloNfse { get; set; }
 

--- a/src/OpenAC.Net.NFSe/Nota/NotaServico.cs
+++ b/src/OpenAC.Net.NFSe/Nota/NotaServico.cs
@@ -186,6 +186,8 @@ public sealed class NotaServico : GenericClone<NotaServico>, INotifyPropertyChan
 
     public string XmlOriginal { get; set; }
 
+    public string XmlRetornoComplementarIBSCBS { get; set; }
+
     public string LinkNFSe { get; set; }
 
     public EventoRps? Evento { get; set; }

--- a/src/OpenAC.Net.NFSe/Nota/ValoresServico.cs
+++ b/src/OpenAC.Net.NFSe/Nota/ValoresServico.cs
@@ -55,6 +55,14 @@ public sealed class ValoresServico : GenericClone<ValoresServico>, INotifyProper
 
     public decimal ValorServicos { get; set; }
 
+    public decimal? ValorInicialCobrado { get; set; }
+
+    public decimal? ValorFinalCobrado { get; set; }
+
+    public decimal? ValorIpi { get; set; }
+
+    public bool? ExigibilidadeSuspensa { get; set; }
+
     public decimal ValorDeducoes { get; set; }
 
     public decimal ValorPis { get; set; }

--- a/src/OpenAC.Net.NFSe/OpenAC.Net.NFSe.csproj
+++ b/src/OpenAC.Net.NFSe/OpenAC.Net.NFSe.csproj
@@ -256,7 +256,10 @@
 	<ItemGroup>
 		<None Remove="Resources\Municipios.nfse" />
 		<EmbeddedResource Include="Resources\Municipios.nfse" />
-        
+	</ItemGroup>
+
+	<!-- Consumidores que mantêm schemas próprios podem desabilitar apenas a cópia para a saída. -->
+	<ItemGroup Condition="'$(CopySchemasToOutputDirectory)' != 'false'">
 		<None Update="Schemas\Abaco\**\*.*">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
@@ -428,7 +431,7 @@
 	  <Folder Include="Schemas\ISSCampinas\2.03\" />
 	</ItemGroup>
 	
-	<ItemGroup>
+	<ItemGroup Condition="'$(CopySchemasToOutputDirectory)' != 'false'">
 	  <None Update="Schemas\ISSCampinas\2.03\nfse.xsd">
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	  </None>

--- a/src/OpenAC.Net.NFSe/Providers/ISSSaoPaulo/ISSSaoPauloLayout2.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ISSSaoPaulo/ISSSaoPauloLayout2.cs
@@ -1,0 +1,461 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Xml.Linq;
+using OpenAC.Net.Core;
+using OpenAC.Net.Core.Extensions;
+using OpenAC.Net.NFSe.Nota;
+
+namespace OpenAC.Net.NFSe.Providers;
+
+/// <summary>
+/// Serialização e assinatura do RPS do Layout 2 da Prefeitura de São Paulo.
+/// </summary>
+public static class ISSSaoPauloLayout2
+{
+    /// <summary>
+    /// Serializa um RPS no Layout 2.
+    /// </summary>
+    public static string WriteXmlRps(NotaServico nota, X509Certificate2 certificado, bool identado = true,
+        bool showDeclaration = true)
+    {
+        if (certificado == null)
+            throw new ArgumentNullException(nameof(certificado));
+
+        var xmlDoc = new XDocument(new XDeclaration("1.0", "UTF-8", null), WriteRps(nota, certificado));
+        return xmlDoc.AsString(identado, showDeclaration, Encoding.UTF8);
+    }
+
+    /// <summary>
+    /// Monta a cadeia ASCII definida nas páginas 46 a 48 do manual NFe_Web_Service 3.3.7.
+    /// </summary>
+    public static string MontarCadeiaAssinatura(NotaServico nota)
+    {
+        Validar(nota);
+
+        var tipoTributacao = ObterTipoTributacao(nota.TipoTributacao);
+        var situacao = nota.Situacao == SituacaoNFSeRps.Normal ? "N" : "C";
+        var issRetido = nota.Servico.Valores.IssRetido == SituacaoTributaria.Retencao ? "S" : "N";
+        var valorCobrado = nota.Servico.Valores.ValorInicialCobrado ??
+                           nota.Servico.Valores.ValorFinalCobrado!.Value;
+
+        ObterDocumentoTomador(nota, out var indicadorTomador, out var documentoTomador, out var nifNaoNif);
+
+        var cadeia = new StringBuilder();
+        cadeia.Append(PreencherNumero(nota.Prestador.InscricaoMunicipal, 12, "Inscrição Municipal do prestador"));
+        cadeia.Append(PreencherSerie(nota.IdentificacaoRps.Serie));
+        cadeia.Append(PreencherNumero(nota.IdentificacaoRps.Numero, 12, "Número do RPS"));
+        cadeia.Append(nota.IdentificacaoRps.DataEmissao.ToString("yyyyMMdd", CultureInfo.InvariantCulture));
+        cadeia.Append(tipoTributacao);
+        cadeia.Append(situacao);
+        cadeia.Append(issRetido);
+        cadeia.Append(FormatarValorAssinatura(valorCobrado));
+        cadeia.Append(FormatarValorAssinatura(nota.Servico.Valores.ValorDeducoes));
+        cadeia.Append(PreencherNumero(nota.Servico.ItemListaServico, 5, "Código do serviço"));
+        cadeia.Append(indicadorTomador);
+        cadeia.Append(documentoTomador);
+
+        if (!string.IsNullOrWhiteSpace(nota.Intermediario.CpfCnpj))
+        {
+            var documentoIntermediario = SomenteDigitos(nota.Intermediario.CpfCnpj,
+                "CPF/CNPJ do intermediário");
+            var indicadorIntermediario = documentoIntermediario.Length switch
+            {
+                11 => "1",
+                14 => "2",
+                _ => throw new OpenException("Layout 2 de São Paulo: CPF/CNPJ do intermediário deve conter 11 ou 14 dígitos.")
+            };
+
+            cadeia.Append(indicadorIntermediario);
+            cadeia.Append(documentoIntermediario.PadLeft(14, '0'));
+            cadeia.Append(nota.Intermediario.IssRetido == SituacaoTributaria.Retencao ? "S" : "N");
+        }
+
+        cadeia.Append(nifNaoNif);
+        return cadeia.ToString();
+    }
+
+    /// <summary>
+    /// Assina a cadeia do Layout 2 com RSA-SHA1 e preenchimento PKCS#1 v1.5.
+    /// </summary>
+    public static string AssinarRps(NotaServico nota, RSA rsa)
+    {
+        if (rsa == null)
+            throw new ArgumentNullException(nameof(rsa));
+
+        var cadeia = MontarCadeiaAssinatura(nota);
+        var assinatura = rsa.SignData(Encoding.ASCII.GetBytes(cadeia), HashAlgorithmName.SHA1,
+            RSASignaturePadding.Pkcs1);
+        return Convert.ToBase64String(assinatura);
+    }
+
+    /// <summary>
+    /// Retorna o código de retenção de PIS/COFINS/CSLL específico do Layout 2 de São Paulo.
+    /// </summary>
+    public static int ObterRetencaoPisCofins(ValoresServico valores)
+    {
+        if (valores == null)
+            throw new ArgumentNullException(nameof(valores));
+
+        var pis = valores.ValorPis > 0;
+        var cofins = valores.ValorCofins > 0;
+        var csll = valores.ValorCsll > 0;
+
+        var combinacao = (pis ? 1 : 0) | (cofins ? 2 : 0) | (csll ? 4 : 0);
+        return combinacao switch
+        {
+            0 => 0,
+            7 => 3,
+            3 => 4,
+            1 => 5,
+            2 => 6,
+            6 => 7,
+            4 => 8,
+            5 => 9,
+            _ => throw new InvalidOperationException()
+        };
+    }
+
+    private static XElement WriteRps(NotaServico nota, X509Certificate2 certificado)
+    {
+        Validar(nota);
+
+        using var rsa = certificado.GetRSAPrivateKey();
+        if (rsa == null)
+            throw new OpenException("Layout 2 de São Paulo: o certificado não possui chave privada RSA.");
+
+        var valores = nota.Servico.Valores;
+        var rps = new XElement("RPS",
+            new XElement("Assinatura", AssinarRps(nota, rsa)),
+            new XElement("ChaveRPS",
+                new XElement("InscricaoPrestador", nota.Prestador.InscricaoMunicipal),
+                string.IsNullOrWhiteSpace(nota.IdentificacaoRps.Serie)
+                    ? null
+                    : new XElement("SerieRPS", nota.IdentificacaoRps.Serie),
+                new XElement("NumeroRPS", nota.IdentificacaoRps.Numero)),
+            new XElement("TipoRPS", ObterTipoRps(nota.IdentificacaoRps.Tipo)),
+            new XElement("DataEmissao", nota.IdentificacaoRps.DataEmissao.ToString("yyyy-MM-dd",
+                CultureInfo.InvariantCulture)),
+            new XElement("StatusRPS", nota.Situacao == SituacaoNFSeRps.Normal ? "N" : "C"),
+            new XElement("TributacaoRPS", ObterTipoTributacao(nota.TipoTributacao)),
+            ElementoValor("ValorDeducoes", valores.ValorDeducoes),
+            ElementoValor("ValorPIS", valores.ValorPis),
+            ElementoValor("ValorCOFINS", valores.ValorCofins),
+            ElementoValor("ValorINSS", valores.ValorInss),
+            ElementoValor("ValorIR", valores.ValorIr),
+            ElementoValor("ValorCSLL", valores.ValorCsll),
+            new XElement("CodigoServico", nota.Servico.ItemListaServico),
+            new XElement("AliquotaServicos", (valores.Aliquota / 100M).ToString("0.0000",
+                CultureInfo.InvariantCulture)),
+            new XElement("ISSRetido", valores.IssRetido == SituacaoTributaria.Retencao
+                ? "true"
+                : "false"));
+
+        WriteTomador(rps, nota);
+        WriteIntermediario(rps, nota);
+
+        rps.Add(new XElement("Discriminacao", nota.Servico.Discriminacao));
+
+        if (valores.ValorCargaTributaria > 0)
+            rps.Add(ElementoValor("ValorCargaTributaria", valores.ValorCargaTributaria));
+        if (valores.AliquotaCargaTributaria > 0)
+            rps.Add(new XElement("PercentualCargaTributaria",
+                (valores.AliquotaCargaTributaria / 100M).ToString("0.0000", CultureInfo.InvariantCulture)));
+        if (!string.IsNullOrWhiteSpace(valores.FonteCargaTributaria))
+            rps.Add(new XElement("FonteCargaTributaria", valores.FonteCargaTributaria));
+        if (!string.IsNullOrWhiteSpace(nota.ConstrucaoCivil.CodigoCEI))
+            rps.Add(new XElement("CodigoCEI", nota.ConstrucaoCivil.CodigoCEI));
+        if (!string.IsNullOrWhiteSpace(nota.ConstrucaoCivil.Matricula))
+            rps.Add(new XElement("MatriculaObra", nota.ConstrucaoCivil.Matricula));
+        if (nota.Material.NumeroEncapsulamento > 0)
+            rps.Add(new XElement("NumeroEncapsulamento", nota.Material.NumeroEncapsulamento));
+
+        rps.Add(new XElement("RetencaoPisCofins", ObterRetencaoPisCofins(valores)));
+        rps.Add(valores.ValorInicialCobrado.HasValue
+            ? ElementoValor("ValorInicialCobrado", valores.ValorInicialCobrado.Value)
+            : ElementoValor("ValorFinalCobrado", valores.ValorFinalCobrado!.Value));
+        rps.Add(ElementoValor("ValorIPI", valores.ValorIpi!.Value));
+        rps.Add(new XElement("ExigibilidadeSuspensa", valores.ExigibilidadeSuspensa!.Value ? 1 : 0));
+        rps.Add(new XElement("NBS", nota.Servico.CodigoNbs));
+
+        var codigoLocalPrestacao = nota.Servico.MunicipioIncidencia > 0
+            ? nota.Servico.MunicipioIncidencia
+            : nota.Servico.CodigoMunicipio;
+        rps.Add(new XElement("cLocPrestacao", codigoLocalPrestacao));
+        rps.Add(WriteIBSCBS(nota));
+
+        return rps;
+    }
+
+    private static XElement WriteIBSCBS(NotaServico nota)
+    {
+        var info = nota.Servico.Valores.IBSCBS!;
+        var codigoOperacao = ObterCodigoOperacao(nota);
+        var classificacao = ObterClassificacaoTributaria(nota);
+
+        return new XElement("IBSCBS",
+            new XElement("finNFSe", info.FinalidadeNFSe),
+            new XElement("indFinal", info.IndicadorFinal),
+            new XElement("cIndOp", codigoOperacao),
+            new XElement("indDest", info.IndicadorDestinatario),
+            new XElement("valores",
+                new XElement("trib",
+                    new XElement("gIBSCBS",
+                        new XElement("cClassTrib", classificacao)))));
+    }
+
+    private static void WriteTomador(XElement rps, NotaServico nota)
+    {
+        var tomador = nota.Tomador;
+        if (!string.IsNullOrWhiteSpace(tomador.CpfCnpj) ||
+            !string.IsNullOrWhiteSpace(tomador.DocEstrangeiro) ||
+            !string.IsNullOrWhiteSpace(tomador.CodNaoNif))
+        {
+            var documento = new XElement("CPFCNPJTomador");
+            if (!string.IsNullOrWhiteSpace(tomador.CpfCnpj))
+            {
+                var cpfCnpj = SomenteDigitos(tomador.CpfCnpj, "CPF/CNPJ do tomador");
+                documento.Add(cpfCnpj.Length switch
+                {
+                    11 => new XElement("CPF", cpfCnpj),
+                    14 => new XElement("CNPJ", cpfCnpj),
+                    _ => throw new OpenException("Layout 2 de São Paulo: CPF/CNPJ do tomador deve conter 11 ou 14 dígitos.")
+                });
+            }
+            else if (!string.IsNullOrWhiteSpace(tomador.DocEstrangeiro))
+            {
+                documento.Add(new XElement("NIF", tomador.DocEstrangeiro));
+            }
+            else
+            {
+                documento.Add(new XElement("NaoNIF", tomador.CodNaoNif));
+            }
+
+            rps.Add(documento);
+        }
+
+        if (!string.IsNullOrWhiteSpace(tomador.InscricaoMunicipal))
+            rps.Add(new XElement("InscricaoMunicipalTomador", tomador.InscricaoMunicipal));
+        if (!string.IsNullOrWhiteSpace(tomador.InscricaoEstadual))
+            rps.Add(new XElement("InscricaoEstadualTomador", tomador.InscricaoEstadual));
+        if (!string.IsNullOrWhiteSpace(tomador.RazaoSocial))
+            rps.Add(new XElement("RazaoSocialTomador", tomador.RazaoSocial));
+
+        if (!string.IsNullOrWhiteSpace(tomador.Endereco.Logradouro))
+        {
+            var endereco = new XElement("EnderecoTomador");
+            if (!string.IsNullOrWhiteSpace(tomador.Endereco.TipoLogradouro))
+                endereco.Add(new XElement("TipoLogradouro", tomador.Endereco.TipoLogradouro));
+            endereco.Add(new XElement("Logradouro", tomador.Endereco.Logradouro));
+            endereco.Add(new XElement("NumeroEndereco", tomador.Endereco.Numero));
+            if (!string.IsNullOrWhiteSpace(tomador.Endereco.Complemento))
+                endereco.Add(new XElement("ComplementoEndereco", tomador.Endereco.Complemento));
+            if (!string.IsNullOrWhiteSpace(tomador.Endereco.Bairro))
+                endereco.Add(new XElement("Bairro", tomador.Endereco.Bairro));
+            if (tomador.Endereco.CodigoMunicipio > 0)
+                endereco.Add(new XElement("Cidade", tomador.Endereco.CodigoMunicipio));
+            if (!string.IsNullOrWhiteSpace(tomador.Endereco.Uf))
+                endereco.Add(new XElement("UF", tomador.Endereco.Uf));
+            if (!string.IsNullOrWhiteSpace(tomador.Endereco.Cep))
+                endereco.Add(new XElement("CEP", SomenteDigitos(tomador.Endereco.Cep, "CEP do tomador")));
+            rps.Add(endereco);
+        }
+
+        if (!string.IsNullOrWhiteSpace(tomador.DadosContato.Email))
+            rps.Add(new XElement("EmailTomador", tomador.DadosContato.Email));
+    }
+
+    private static void WriteIntermediario(XElement rps, NotaServico nota)
+    {
+        if (string.IsNullOrWhiteSpace(nota.Intermediario.CpfCnpj))
+            return;
+
+        var cpfCnpj = SomenteDigitos(nota.Intermediario.CpfCnpj, "CPF/CNPJ do intermediário");
+        var documento = new XElement("CPFCNPJIntermediario",
+            cpfCnpj.Length switch
+            {
+                11 => new XElement("CPF", cpfCnpj),
+                14 => new XElement("CNPJ", cpfCnpj),
+                _ => throw new OpenException("Layout 2 de São Paulo: CPF/CNPJ do intermediário deve conter 11 ou 14 dígitos.")
+            });
+        rps.Add(documento);
+
+        if (!string.IsNullOrWhiteSpace(nota.Intermediario.InscricaoMunicipal))
+            rps.Add(new XElement("InscricaoMunicipalIntermediario", nota.Intermediario.InscricaoMunicipal));
+        rps.Add(new XElement("ISSRetidoIntermediario",
+            nota.Intermediario.IssRetido == SituacaoTributaria.Retencao ? "true" : "false"));
+        if (!string.IsNullOrWhiteSpace(nota.Intermediario.EMail))
+            rps.Add(new XElement("EmailIntermediario", nota.Intermediario.EMail));
+    }
+
+    private static void Validar(NotaServico nota)
+    {
+        if (nota == null)
+            throw new ArgumentNullException(nameof(nota));
+
+        _ = PreencherNumero(nota.Prestador.InscricaoMunicipal, 12, "Inscrição Municipal do prestador");
+        _ = PreencherSerie(nota.IdentificacaoRps.Serie);
+        _ = PreencherNumero(nota.IdentificacaoRps.Numero, 12, "Número do RPS");
+        _ = PreencherNumero(nota.Servico.ItemListaServico, 5, "Código do serviço");
+
+        var valores = nota.Servico.Valores;
+        if (valores.ValorInicialCobrado.HasValue == valores.ValorFinalCobrado.HasValue)
+            throw new OpenException("Layout 2 de São Paulo: informe exatamente um entre ValorInicialCobrado e ValorFinalCobrado.");
+        if (!valores.ValorIpi.HasValue)
+            throw new OpenException("Layout 2 de São Paulo: ValorIPI deve ser informado.");
+        if (!valores.ExigibilidadeSuspensa.HasValue)
+            throw new OpenException("Layout 2 de São Paulo: ExigibilidadeSuspensa deve ser informada.");
+        if (!PossuiSomenteDigitos(nota.Servico.CodigoNbs, 9))
+            throw new OpenException("Layout 2 de São Paulo: NBS deve conter exatamente 9 dígitos.");
+
+        var codigoLocalPrestacao = nota.Servico.MunicipioIncidencia > 0
+            ? nota.Servico.MunicipioIncidencia
+            : nota.Servico.CodigoMunicipio;
+        if (!PossuiSomenteDigitos(codigoLocalPrestacao.ToString(CultureInfo.InvariantCulture), 7))
+            throw new OpenException("Layout 2 de São Paulo: cLocPrestacao deve conter um código IBGE com 7 dígitos.");
+
+        var info = valores.IBSCBS;
+        if (info == null)
+            throw new OpenException("Layout 2 de São Paulo: o grupo IBSCBS deve ser informado.");
+        if (info.FinalidadeNFSe != "0")
+            throw new OpenException("Layout 2 de São Paulo: finNFSe deve ser informado com valor 0 para emissão regular.");
+        if (info.IndicadorFinal is not ("0" or "1"))
+            throw new OpenException("Layout 2 de São Paulo: indFinal deve ser 0 ou 1.");
+        if (!PossuiSomenteDigitos(ObterCodigoOperacao(nota), 6))
+            throw new OpenException("Layout 2 de São Paulo: cIndOp deve conter exatamente 6 dígitos.");
+        if (info.IndicadorDestinatario is not ("0" or "1"))
+            throw new OpenException("Layout 2 de São Paulo: indDest deve ser 0 ou 1.");
+        if (!PossuiSomenteDigitos(ObterClassificacaoTributaria(nota), 6))
+            throw new OpenException("Layout 2 de São Paulo: cClassTrib deve conter exatamente 6 dígitos.");
+
+        ObterDocumentoTomador(nota, out _, out _, out _);
+    }
+
+    private static void ObterDocumentoTomador(NotaServico nota, out string indicador, out string documento,
+        out string nifNaoNif)
+    {
+        indicador = "3";
+        documento = new string('0', 14);
+        nifNaoNif = string.Empty;
+
+        if (!string.IsNullOrWhiteSpace(nota.Tomador.CpfCnpj))
+        {
+            var cpfCnpj = SomenteDigitos(nota.Tomador.CpfCnpj, "CPF/CNPJ do tomador");
+            indicador = cpfCnpj.Length switch
+            {
+                11 => "1",
+                14 => "2",
+                _ => throw new OpenException("Layout 2 de São Paulo: CPF/CNPJ do tomador deve conter 11 ou 14 dígitos.")
+            };
+            documento = cpfCnpj.PadLeft(14, '0');
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(nota.Tomador.DocEstrangeiro))
+        {
+            var nif = nota.Tomador.DocEstrangeiro.Trim();
+            if (nif.Length > 40 || nif.Any(c => c > 127))
+                throw new OpenException("Layout 2 de São Paulo: NIF deve conter no máximo 40 caracteres ASCII.");
+            indicador = "4";
+            nifNaoNif = nif;
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(nota.Tomador.CodNaoNif))
+        {
+            if (nota.Tomador.CodNaoNif is not ("0" or "1" or "2"))
+                throw new OpenException("Layout 2 de São Paulo: NaoNIF deve ser 0, 1 ou 2.");
+            indicador = "4";
+            nifNaoNif = nota.Tomador.CodNaoNif;
+        }
+    }
+
+    private static string ObterCodigoOperacao(NotaServico nota)
+    {
+        var codigo = nota.Servico.Valores.IBSCBS?.CodigoIndicadorOperacao;
+        return string.IsNullOrWhiteSpace(codigo) ? nota.Servico.CodigoIndicadorOperacao : codigo;
+    }
+
+    private static string ObterClassificacaoTributaria(NotaServico nota)
+    {
+        var codigo = nota.Servico.Valores.IBSCBS?.Valores?.Tributos?.SituacaoClassificacao
+            ?.CodigoClassificacaoTributaria;
+        return string.IsNullOrWhiteSpace(codigo) ? nota.Servico.CodigoClassificacaoTributaria : codigo;
+    }
+
+    private static string ObterTipoRps(TipoRps tipo)
+    {
+        return tipo switch
+        {
+            TipoRps.RPS => "RPS",
+            TipoRps.NFConjugada => "RPS-M",
+            TipoRps.Cupom => "RPS-C",
+            _ => throw new OpenException("Layout 2 de São Paulo: TipoRPS inválido.")
+        };
+    }
+
+    private static string ObterTipoTributacao(TipoTributacao tipo)
+    {
+        return tipo switch
+        {
+            TipoTributacao.Tributavel => "T",
+            TipoTributacao.ForaMun => "F",
+            TipoTributacao.Isenta => "A",
+            TipoTributacao.ForaMunIsento => "B",
+            TipoTributacao.Imune => "M",
+            TipoTributacao.ForaMunImune => "N",
+            TipoTributacao.Suspensa => "X",
+            TipoTributacao.ForaMunSuspensa => "V",
+            TipoTributacao.ExpServicos => "P",
+            _ => throw new OpenException("Layout 2 de São Paulo: TributacaoRPS inválida.")
+        };
+    }
+
+    private static XElement ElementoValor(string nome, decimal valor)
+    {
+        return new XElement(nome, valor.ToString("0.00", CultureInfo.InvariantCulture));
+    }
+
+    private static string FormatarValorAssinatura(decimal valor)
+    {
+        if (valor < 0)
+            throw new OpenException("Layout 2 de São Paulo: valores da assinatura não podem ser negativos.");
+
+        var valorSemSeparador = valor.ToString("0.00", CultureInfo.InvariantCulture).Replace(".", string.Empty);
+        if (valorSemSeparador.Length > 15)
+            throw new OpenException("Layout 2 de São Paulo: valor excede as 15 posições da assinatura.");
+        return valorSemSeparador.PadLeft(15, '0');
+    }
+
+    private static string PreencherNumero(string valor, int tamanho, string campo)
+    {
+        var digitos = SomenteDigitos(valor, campo);
+        if (digitos.Length == 0 || digitos.Length > tamanho)
+            throw new OpenException($"Layout 2 de São Paulo: {campo} deve conter de 1 a {tamanho} dígitos.");
+        return digitos.PadLeft(tamanho, '0');
+    }
+
+    private static string PreencherSerie(string serie)
+    {
+        serie ??= string.Empty;
+        if (serie.Length > 5 || serie.Any(c => c > 127) || (serie.Length > 0 && char.IsWhiteSpace(serie[0])))
+            throw new OpenException("Layout 2 de São Paulo: Série do RPS deve conter até 5 caracteres ASCII, sem espaços à esquerda.");
+        return serie.PadRight(5, ' ');
+    }
+
+    private static string SomenteDigitos(string valor, string campo)
+    {
+        valor ??= string.Empty;
+        if (valor.Any(c => !char.IsDigit(c)))
+            throw new OpenException($"Layout 2 de São Paulo: {campo} deve conter somente dígitos.");
+        return valor;
+    }
+
+    private static bool PossuiSomenteDigitos(string valor, int tamanho)
+    {
+        return valor?.Length == tamanho && valor.All(c => c >= '0' && c <= '9');
+    }
+}

--- a/src/OpenAC.Net.NFSe/Providers/ISSSaoPaulo/ISSSaoPauloServiceClient.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ISSSaoPaulo/ISSSaoPauloServiceClient.cs
@@ -43,10 +43,13 @@ namespace OpenAC.Net.NFSe.Providers;
 
 internal sealed class ISSSaoPauloServiceClient : NFSeSoapServiceClient, IServiceClient
 {
+    private readonly ProviderISSSaoPaulo provider;
+
     #region Constructors
 
     public ISSSaoPauloServiceClient(ProviderISSSaoPaulo provider, TipoUrl tipoUrl) : base(provider, tipoUrl, SoapVersion.Soap12)
     {
+        this.provider = provider;
     }
 
     #endregion Constructors
@@ -71,7 +74,7 @@ internal sealed class ISSSaoPauloServiceClient : NFSeSoapServiceClient, IService
 
         var message = new StringBuilder();
         message.Append($"<nfe:{tag}>");
-        message.Append("<nfe:VersaoSchema>1</nfe:VersaoSchema>");
+        message.Append($"<nfe:VersaoSchema>{provider.NumeroLayout}</nfe:VersaoSchema>");
         message.Append("<nfe:MensagemXML>");
         message.AppendCData(msg);
         message.Append("</nfe:MensagemXML>");
@@ -84,7 +87,7 @@ internal sealed class ISSSaoPauloServiceClient : NFSeSoapServiceClient, IService
     {
         var message = new StringBuilder();
         message.Append("<nfe:EnvioRPSRequest>");
-        message.Append("<nfe:VersaoSchema>1</nfe:VersaoSchema>");
+        message.Append($"<nfe:VersaoSchema>{provider.NumeroLayout}</nfe:VersaoSchema>");
         message.Append("<nfe:MensagemXML>");
         message.AppendCData(msg);
         message.Append("</nfe:MensagemXML>");
@@ -97,7 +100,7 @@ internal sealed class ISSSaoPauloServiceClient : NFSeSoapServiceClient, IService
     {
         var message = new StringBuilder();
         message.Append("<nfe:ConsultaInformacoesLoteRequest>");
-        message.Append("<nfe:VersaoSchema>1</nfe:VersaoSchema>");
+        message.Append($"<nfe:VersaoSchema>{provider.NumeroLayout}</nfe:VersaoSchema>");
         message.Append("<nfe:MensagemXML>");
         message.AppendCData(msg);
         message.Append("</nfe:MensagemXML>");
@@ -110,7 +113,7 @@ internal sealed class ISSSaoPauloServiceClient : NFSeSoapServiceClient, IService
     {
         var message = new StringBuilder();
         message.Append("<nfe:ConsultaLoteRequest>");
-        message.Append("<nfe:VersaoSchema>1</nfe:VersaoSchema>");
+        message.Append($"<nfe:VersaoSchema>{provider.NumeroLayout}</nfe:VersaoSchema>");
         message.Append("<nfe:MensagemXML>");
         message.AppendCData(msg);
         message.Append("</nfe:MensagemXML>");
@@ -133,7 +136,7 @@ internal sealed class ISSSaoPauloServiceClient : NFSeSoapServiceClient, IService
     {
         var message = new StringBuilder();
         message.Append("<nfe:ConsultaNFeRequest>");
-        message.Append("<nfe:VersaoSchema>1</nfe:VersaoSchema>");
+        message.Append($"<nfe:VersaoSchema>{provider.NumeroLayout}</nfe:VersaoSchema>");
         message.Append("<nfe:MensagemXML>");
         message.AppendCData(msg);
         message.Append("</nfe:MensagemXML>");
@@ -146,7 +149,7 @@ internal sealed class ISSSaoPauloServiceClient : NFSeSoapServiceClient, IService
     {
         var message = new StringBuilder();
         message.Append("<nfe:CancelamentoNFeRequest>");
-        message.Append("<nfe:VersaoSchema>1</nfe:VersaoSchema>");
+        message.Append($"<nfe:VersaoSchema>{provider.NumeroLayout}</nfe:VersaoSchema>");
         message.Append("<nfe:MensagemXML>");
         message.AppendCData(msg);
         message.Append("</nfe:MensagemXML>");

--- a/src/OpenAC.Net.NFSe/Providers/ISSSaoPaulo/ProviderISSSaoPaulo.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ISSSaoPaulo/ProviderISSSaoPaulo.cs
@@ -82,9 +82,11 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
         // Nota Fiscal
         ret.IdentificacaoNFSe.Numero = rootDoc.ElementAnyNs("ChaveNFe")?.ElementAnyNs("NumeroNFe")?.GetValue<string>() ?? string.Empty;
         ret.IdentificacaoNFSe.Chave = rootDoc.ElementAnyNs("ChaveNFe")?.ElementAnyNs("CodigoVerificacao")?.GetValue<string>() ?? string.Empty;
+        ret.IdentificacaoNFSe.ChaveNotaNacional = rootDoc.ElementAnyNs("ChaveNFe")?.ElementAnyNs("ChaveNotaNacional")?.GetValue<string>() ?? string.Empty;
         ret.Prestador.InscricaoMunicipal = rootDoc.ElementAnyNs("ChaveNFe")?.ElementAnyNs("InscricaoPrestador")?.GetValue<string>() ?? string.Empty;
 
         ret.IdentificacaoNFSe.DataEmissao = rootDoc.ElementAnyNs("DataEmissaoNFe")?.GetValue<DateTime>() ?? DateTime.MinValue;
+        ret.IdentificacaoNFSe.DataFatoGerador = rootDoc.ElementAnyNs("DataFatoGeradorNFe")?.GetValue<DateTime>();
         ret.NumeroLote = rootDoc.ElementAnyNs("NumeroLote")?.GetValue<int>() ?? 0;
 
         // RPS
@@ -163,6 +165,13 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
 
         ret.Servico.Discriminacao = rootDoc.ElementAnyNs("Discriminacao")?.GetValue<string>() ?? string.Empty;
         ret.Servico.Valores.ValorServicos = rootDoc.ElementAnyNs("ValorServicos")?.GetValue<decimal>() ?? 0;
+        ret.Servico.Valores.ValorInicialCobrado = rootDoc.ElementAnyNs("ValorInicialCobrado")?.GetValue<decimal>();
+        ret.Servico.Valores.ValorFinalCobrado = rootDoc.ElementAnyNs("ValorFinalCobrado")?.GetValue<decimal>();
+        ret.Servico.Valores.ValorIpi = rootDoc.ElementAnyNs("ValorIPI")?.GetValue<decimal>();
+        var exigibilidadeSuspensa = rootDoc.ElementAnyNs("ExigibilidadeSuspensa")?.GetValue<int>();
+        ret.Servico.Valores.ExigibilidadeSuspensa = exigibilidadeSuspensa.HasValue
+            ? exigibilidadeSuspensa.Value == 1
+            : null;
         ret.Servico.Valores.Aliquota = rootDoc.ElementAnyNs("AliquotaServicos")?.GetValue<decimal>() ?? 0;
         ret.Servico.Valores.ValorIss = rootDoc.ElementAnyNs("ValorISS")?.GetValue<decimal>() ?? 0;
         ret.Servico.ItemListaServico = rootDoc.ElementAnyNs("CodigoServico")?.GetValue<string>() ?? string.Empty;
@@ -170,6 +179,28 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
         ret.Servico.Valores.AliquotaCargaTributaria = rootDoc.ElementAnyNs("PercentualCargaTributaria")?.GetValue<decimal>() ?? 0;
         ret.Servico.Valores.FonteCargaTributaria = rootDoc.ElementAnyNs("FonteCargaTributaria")?.GetValue<string>() ?? string.Empty;
         ret.ValorCredito = rootDoc.ElementAnyNs("ValorCredito")?.GetValue<decimal>() ?? 0;
+        ret.Servico.CodigoNbs = rootDoc.ElementAnyNs("NBS")?.GetValue<string>() ?? string.Empty;
+        ret.Servico.MunicipioIncidencia = rootDoc.ElementAnyNs("cLocPrestacao")?.GetValue<int>() ?? 0;
+
+        var ibsCbs = rootDoc.ElementAnyNs("IBSCBS");
+        if (ibsCbs != null)
+        {
+            ret.Servico.Valores.IBSCBS = new InfoIBSCBS
+            {
+                FinalidadeNFSe = ibsCbs.ElementAnyNs("finNFSe")?.GetValue<string>(),
+                IndicadorFinal = ibsCbs.ElementAnyNs("indFinal")?.GetValue<string>(),
+                CodigoIndicadorOperacao = ibsCbs.ElementAnyNs("cIndOp")?.GetValue<string>(),
+                IndicadorDestinatario = ibsCbs.ElementAnyNs("indDest")?.GetValue<string>()
+            };
+            ret.Servico.Valores.IBSCBS.Valores.Tributos.SituacaoClassificacao.CodigoClassificacaoTributaria =
+                ibsCbs.ElementAnyNs("valores")?.ElementAnyNs("trib")?.ElementAnyNs("gIBSCBS")
+                    ?.ElementAnyNs("cClassTrib")?.GetValue<string>();
+        }
+
+        var retornoComplementar = rootDoc.ElementAnyNs("RetornoComplementarIBSCBS");
+        ret.XmlRetornoComplementarIBSCBS = retornoComplementar?.ToString(SaveOptions.DisableFormatting) ??
+                                           string.Empty;
+        ret.XmlOriginal = rootDoc.ToString(SaveOptions.DisableFormatting);
 
         switch (rootDoc.ElementAnyNs("ISSRetido")?.GetValue<string>() ?? string.Empty)
         {
@@ -223,6 +254,9 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
 
     public override string WriteXmlRps(NotaServico nota, bool identado, bool showDeclaration)
     {
+        if (Configuracoes.WebServices.LayoutISSSaoPaulo == LayoutISSSaoPaulo.Layout2)
+            return ISSSaoPauloLayout2.WriteXmlRps(nota, Certificado, identado, showDeclaration);
+
         string tipoRps = nota.IdentificacaoRps.Tipo switch
         {
             TipoRps.RPS => "RPS",
@@ -346,6 +380,12 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
 
     protected override void PrepararEnviar(RetornoEnviar retornoWebservice, NotaServicoCollection notas)
     {
+        if (Configuracoes.WebServices.LayoutISSSaoPaulo == LayoutISSSaoPaulo.Layout2)
+        {
+            PrepararEnviarLayout2(retornoWebservice, notas);
+            return;
+        }
+
         if (retornoWebservice.Lote == 0)
             retornoWebservice.Erros.Add(new EventoRetorno { Codigo = "0", Descricao = "Lote não informado." });
 
@@ -404,20 +444,64 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
         {
             nota.NumeroLote = retornoWebservice.Lote;
         }
+
+        if (NumeroLayout == 2)
+            AtualizarChavesRetornadas(xmlRet, notas);
     }
 
     protected override void PrepararEnviarSincrono(RetornoEnviar retornoWebservice, NotaServicoCollection notas)
     {
+        if (Configuracoes.WebServices.LayoutISSSaoPaulo == LayoutISSSaoPaulo.Layout2)
+        {
+            if (notas.Count != 1)
+            {
+                retornoWebservice.Erros.Add(new EventoRetorno
+                {
+                    Codigo = "0",
+                    Descricao = "O envio individual do Layout 2 de São Paulo exige exatamente um RPS."
+                });
+                return;
+            }
+
+            var root = CriarRaizPedido("PedidoEnvioRPS");
+            root.Add(CriarCabecalhoRemetente());
+            root.Add(XElement.Parse(WriteXmlRps(notas[0], false, false)));
+            retornoWebservice.XmlEnvio = new XDocument(new XDeclaration("1.0", "UTF-8", null), root)
+                .ToString(SaveOptions.DisableFormatting);
+            return;
+        }
+
         throw new NotImplementedException("Função não implementada/suportada neste Provedor !");
     }
 
     protected override void AssinarEnviarSincrono(RetornoEnviar retornoWebservice)
     {
+        if (Configuracoes.WebServices.LayoutISSSaoPaulo == LayoutISSSaoPaulo.Layout2)
+        {
+            retornoWebservice.XmlEnvio = XmlSigning.AssinarXml(retornoWebservice.XmlEnvio, "PedidoEnvioRPS", "",
+                Certificado);
+            return;
+        }
+
         throw new NotImplementedException("Função não implementada/suportada neste Provedor !");
     }
 
     protected override void TratarRetornoEnviarSincrono(RetornoEnviar retornoWebservice, NotaServicoCollection notas)
     {
+        if (Configuracoes.WebServices.LayoutISSSaoPaulo == LayoutISSSaoPaulo.Layout2)
+        {
+            var xmlRet = XDocument.Parse(retornoWebservice.XmlRetorno);
+            MensagemErro(retornoWebservice, xmlRet, "RetornoEnvioRPS");
+            if (retornoWebservice.Erros.Any())
+                return;
+
+            retornoWebservice.Sucesso =
+                xmlRet.Root?.ElementAnyNs("Cabecalho")?.ElementAnyNs("Sucesso")?.GetValue<bool>() ?? false;
+            if (retornoWebservice.Sucesso)
+                AtualizarChavesRetornadas(xmlRet, notas);
+            return;
+        }
+
         throw new NotImplementedException("Função não implementada/suportada neste Provedor !");
     }
 
@@ -426,10 +510,10 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
         var loteBuilder = new StringBuilder();
         loteBuilder.Append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         loteBuilder.Append("<PedidoInformacoesLote xmlns=\"http://www.prefeitura.sp.gov.br/nfe\" xmlns:xsi = \"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd = \"http://www.w3.org/2001/XMLSchema\">");
-        loteBuilder.Append("<Cabecalho xmlns=\"\" Versao=\"1\">");
+        loteBuilder.Append($"<Cabecalho xmlns=\"\" Versao=\"{NumeroLayout}\">");
         loteBuilder.Append($"<CPFCNPJRemetente><CNPJ>{Configuracoes.PrestadorPadrao.CpfCnpj.ZeroFill(14)}</CNPJ></CPFCNPJRemetente>");
         loteBuilder.Append($"<NumeroLote>{retornoWebservice.Lote}</NumeroLote>");
-        loteBuilder.Append($"<InscricaoPrestador>{Configuracoes.PrestadorPadrao.InscricaoMunicipal.ZeroFill(8)}</InscricaoPrestador>");
+        loteBuilder.Append($"<InscricaoPrestador>{Configuracoes.PrestadorPadrao.InscricaoMunicipal.ZeroFill(TamanhoInscricaoMunicipal)}</InscricaoPrestador>");
         loteBuilder.Append("</Cabecalho>");
         loteBuilder.Append("</PedidoInformacoesLote>");
         retornoWebservice.XmlEnvio = loteBuilder.ToString();
@@ -455,7 +539,7 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
         var loteBuilder = new StringBuilder();
         loteBuilder.Append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         loteBuilder.Append("<PedidoConsultaLote xmlns=\"http://www.prefeitura.sp.gov.br/nfe\" xmlns:xsi = \"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd = \"http://www.w3.org/2001/XMLSchema\">");
-        loteBuilder.Append("<Cabecalho xmlns=\"\" Versao=\"1\">");
+        loteBuilder.Append($"<Cabecalho xmlns=\"\" Versao=\"{NumeroLayout}\">");
         loteBuilder.Append($"<CPFCNPJRemetente><CNPJ>{Configuracoes.PrestadorPadrao.CpfCnpj.ZeroFill(14)}</CNPJ></CPFCNPJRemetente>");
         loteBuilder.Append($"<NumeroLote>{retornoWebservice.Lote}</NumeroLote>");
         loteBuilder.Append("</Cabecalho>");
@@ -497,6 +581,10 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
             {
                 nota = LoadXml(nfse.ToString());
                 notas.Add(nota);
+            }
+            else if (NumeroLayout == 2)
+            {
+                AtualizarNotaComRetorno(nota, LoadXml(nfse.ToString(SaveOptions.DisableFormatting)));
             }
             else
             {
@@ -566,6 +654,10 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
         {
             nota = notas.Load(xmlNFSe.ToString());
         }
+        else if (NumeroLayout == 2)
+        {
+            AtualizarNotaComRetorno(nota, LoadXml(xmlNFSe.ToString(SaveOptions.DisableFormatting)));
+        }
         else
         {
             nota.IdentificacaoNFSe.Numero = numeroNFSe;
@@ -617,7 +709,8 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
         }
 
         // Hash Cancelamento
-        var hash = Configuracoes.PrestadorPadrao.InscricaoMunicipal.ZeroFill(8) + retornoWebservice.NumeroNFSe.ZeroFill(12);
+        var hash = Configuracoes.PrestadorPadrao.InscricaoMunicipal.ZeroFill(TamanhoInscricaoMunicipal) +
+                   retornoWebservice.NumeroNFSe.ZeroFill(12);
         var rsa = (RSA)Certificado.GetRSAPrivateKey();
         var hashBytes = Encoding.ASCII.GetBytes(hash);
         var signData = rsa.SignData(hashBytes, HashAlgorithmName.SHA1, RSASignaturePadding.Pkcs1);
@@ -627,13 +720,13 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
         var loteBuilder = new StringBuilder();
         loteBuilder.Append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         loteBuilder.Append("<PedidoCancelamentoNFe xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns=\"http://www.prefeitura.sp.gov.br/nfe\">");
-        loteBuilder.Append("<Cabecalho xmlns=\"\" Versao=\"1\">");
+        loteBuilder.Append($"<Cabecalho xmlns=\"\" Versao=\"{NumeroLayout}\">");
         loteBuilder.Append($"<CPFCNPJRemetente><CNPJ>{Configuracoes.PrestadorPadrao.CpfCnpj.ZeroFill(14)}</CNPJ></CPFCNPJRemetente>");
         loteBuilder.Append($"<transacao>true</transacao>");
         loteBuilder.Append("</Cabecalho>");
         loteBuilder.Append("<Detalhe xmlns=\"\">");
         loteBuilder.Append("<ChaveNFe>");
-        loteBuilder.Append($"<InscricaoPrestador>{Configuracoes.PrestadorPadrao.InscricaoMunicipal.ZeroFill(8)}</InscricaoPrestador>");
+        loteBuilder.Append($"<InscricaoPrestador>{Configuracoes.PrestadorPadrao.InscricaoMunicipal.ZeroFill(TamanhoInscricaoMunicipal)}</InscricaoPrestador>");
         loteBuilder.Append($"<NumeroNFe>{retornoWebservice.NumeroNFSe}</NumeroNFe>");
         loteBuilder.Append("</ChaveNFe>");
         loteBuilder.Append($"<AssinaturaCancelamento>{hashAssinado}</AssinaturaCancelamento>");
@@ -700,12 +793,111 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
 
     #region Private Methods
 
+    internal int NumeroLayout => Configuracoes.WebServices.LayoutISSSaoPaulo == LayoutISSSaoPaulo.Layout2 ? 2 : 1;
+
+    private int TamanhoInscricaoMunicipal => NumeroLayout == 2 ? 12 : 8;
+
+    private void PrepararEnviarLayout2(RetornoEnviar retornoWebservice, NotaServicoCollection notas)
+    {
+        if (retornoWebservice.Lote == 0)
+            retornoWebservice.Erros.Add(new EventoRetorno { Codigo = "0", Descricao = "Lote não informado." });
+        if (notas.Count == 0)
+            retornoWebservice.Erros.Add(new EventoRetorno { Codigo = "0", Descricao = "RPS não informado." });
+        if (notas.Count > 50)
+        {
+            retornoWebservice.Erros.Add(new EventoRetorno
+            {
+                Codigo = "0",
+                Descricao = "O Layout 2 de São Paulo permite no máximo 50 RPS por lote."
+            });
+        }
+
+        if (retornoWebservice.Erros.Count > 0)
+            return;
+
+        var cabecalho = CriarCabecalhoRemetente();
+        cabecalho.Add(
+            new XElement("transacao", "true"),
+            new XElement("dtInicio", notas.Min(x => x.IdentificacaoRps.DataEmissao)
+                .ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+            new XElement("dtFim", notas.Max(x => x.IdentificacaoRps.DataEmissao)
+                .ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+            new XElement("QtdRPS", notas.Count));
+
+        var root = CriarRaizPedido("PedidoEnvioLoteRPS");
+        root.Add(cabecalho);
+        foreach (var nota in notas)
+        {
+            var xmlRps = WriteXmlRps(nota, false, false);
+            root.Add(XElement.Parse(xmlRps));
+            GravarRpsEmDisco(xmlRps,
+                $"Rps-{nota.IdentificacaoRps.DataEmissao:yyyyMMdd}-{nota.IdentificacaoRps.Numero}.xml",
+                nota.IdentificacaoRps.DataEmissao);
+        }
+
+        retornoWebservice.XmlEnvio = new XDocument(new XDeclaration("1.0", "UTF-8", null), root)
+            .ToString(SaveOptions.DisableFormatting);
+    }
+
+    private XElement CriarCabecalhoRemetente()
+    {
+        return new XElement("Cabecalho",
+            new XAttribute("Versao", NumeroLayout),
+            new XElement("CPFCNPJRemetente",
+                new XElement("CNPJ", Configuracoes.PrestadorPadrao.CpfCnpj.ZeroFill(14))));
+    }
+
+    private static XElement CriarRaizPedido(string nome)
+    {
+        XNamespace ns = "http://www.prefeitura.sp.gov.br/nfe";
+        XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
+        XNamespace xsd = "http://www.w3.org/2001/XMLSchema";
+        return new XElement(ns + nome,
+            new XAttribute(XNamespace.Xmlns + "xsi", xsi),
+            new XAttribute(XNamespace.Xmlns + "xsd", xsd));
+    }
+
+    private static void AtualizarChavesRetornadas(XContainer xmlRet, NotaServicoCollection notas)
+    {
+        foreach (var chaveNFeRps in xmlRet.Descendants().Where(x => x.Name.LocalName == "ChaveNFeRPS"))
+        {
+            var chaveRps = chaveNFeRps.ElementAnyNs("ChaveRPS");
+            var numeroRps = chaveRps?.ElementAnyNs("NumeroRPS")?.GetValue<string>() ?? string.Empty;
+            var serieRps = chaveRps?.ElementAnyNs("SerieRPS")?.GetValue<string>() ?? string.Empty;
+            var nota = notas.FirstOrDefault(x =>
+                x.IdentificacaoRps.Numero == numeroRps &&
+                (serieRps.IsEmpty() || x.IdentificacaoRps.Serie == serieRps));
+            if (nota == null)
+                continue;
+
+            var chaveNFe = chaveNFeRps.ElementAnyNs("ChaveNFe");
+            nota.IdentificacaoNFSe.Numero =
+                chaveNFe?.ElementAnyNs("NumeroNFe")?.GetValue<string>() ?? nota.IdentificacaoNFSe.Numero;
+            nota.IdentificacaoNFSe.Chave =
+                chaveNFe?.ElementAnyNs("CodigoVerificacao")?.GetValue<string>() ?? nota.IdentificacaoNFSe.Chave;
+            nota.IdentificacaoNFSe.ChaveNotaNacional =
+                chaveNFe?.ElementAnyNs("ChaveNotaNacional")?.GetValue<string>() ??
+                nota.IdentificacaoNFSe.ChaveNotaNacional;
+        }
+    }
+
+    private static void AtualizarNotaComRetorno(NotaServico destino, NotaServico origem)
+    {
+        destino.IdentificacaoNFSe.Numero = origem.IdentificacaoNFSe.Numero;
+        destino.IdentificacaoNFSe.Chave = origem.IdentificacaoNFSe.Chave;
+        destino.IdentificacaoNFSe.ChaveNotaNacional = origem.IdentificacaoNFSe.ChaveNotaNacional;
+        destino.IdentificacaoNFSe.DataEmissao = origem.IdentificacaoNFSe.DataEmissao;
+        destino.IdentificacaoNFSe.DataFatoGerador = origem.IdentificacaoNFSe.DataFatoGerador;
+        destino.XmlRetornoComplementarIBSCBS = origem.XmlRetornoComplementarIBSCBS;
+        destino.XmlOriginal = origem.XmlOriginal;
+    }
+
     private string ConsultarRPSNFSe(int numeroRPS, string serieRPS, int numeroNFSe)
     {
         var loteBuilder = new StringBuilder();
         loteBuilder.Append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
         loteBuilder.Append("<p1:PedidoConsultaNFe xmlns:p1=\"http://www.prefeitura.sp.gov.br/nfe\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">");
-        loteBuilder.Append("<Cabecalho Versao=\"1\">");
+        loteBuilder.Append($"<Cabecalho Versao=\"{NumeroLayout}\">");
         loteBuilder.Append($"<CPFCNPJRemetente><CNPJ>{Configuracoes.PrestadorPadrao.CpfCnpj.ZeroFill(14)}</CNPJ></CPFCNPJRemetente>");
         loteBuilder.Append("</Cabecalho>");
         loteBuilder.Append("<Detalhe>");
@@ -713,7 +905,7 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
         {
             // RPS
             loteBuilder.Append("<ChaveRPS>");
-            loteBuilder.Append($"<InscricaoPrestador>{Configuracoes.PrestadorPadrao.InscricaoMunicipal.ZeroFill(8)}</InscricaoPrestador>");
+            loteBuilder.Append($"<InscricaoPrestador>{Configuracoes.PrestadorPadrao.InscricaoMunicipal.ZeroFill(TamanhoInscricaoMunicipal)}</InscricaoPrestador>");
             loteBuilder.Append($"<SerieRPS>{serieRPS}</SerieRPS>");
             loteBuilder.Append($"<NumeroRPS>{numeroRPS}</NumeroRPS>");
             loteBuilder.Append("</ChaveRPS>");
@@ -722,7 +914,7 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
         {
             // NFSe
             loteBuilder.Append("<ChaveNFe>");
-            loteBuilder.Append($"<InscricaoPrestador>{Configuracoes.PrestadorPadrao.InscricaoMunicipal.ZeroFill(8)}</InscricaoPrestador>");
+            loteBuilder.Append($"<InscricaoPrestador>{Configuracoes.PrestadorPadrao.InscricaoMunicipal.ZeroFill(TamanhoInscricaoMunicipal)}</InscricaoPrestador>");
             loteBuilder.Append($"<NumeroNFe>{numeroNFSe}</NumeroNFe>");
             loteBuilder.Append("</ChaveNFe>");
         }
@@ -733,17 +925,18 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
 
     protected override string GetSchema(TipoUrl tipo)
     {
+        var sufixo = NumeroLayout == 2 ? "v02" : "v01";
         return tipo switch
         {
-            TipoUrl.Enviar => "PedidoEnvioLoteRPS_v01.xsd",
-            TipoUrl.EnviarSincrono => "PedidoEnvioRPS_v01.xsd",
-            TipoUrl.ConsultarSituacao => "PedidoInformacoesLote_v01.xsd",
-            TipoUrl.ConsultarLoteRps => "PedidoConsultaLote_v01.xsd",
+            TipoUrl.Enviar => $"PedidoEnvioLoteRPS_{sufixo}.xsd",
+            TipoUrl.EnviarSincrono => $"PedidoEnvioRPS_{sufixo}.xsd",
+            TipoUrl.ConsultarSituacao => $"PedidoInformacoesLote_{sufixo}.xsd",
+            TipoUrl.ConsultarLoteRps => $"PedidoConsultaLote_{sufixo}.xsd",
             TipoUrl.ConsultarSequencialRps => "",
-            TipoUrl.ConsultarNFSeRps => "PedidoConsultaNFe_v01.xsd",
-            TipoUrl.ConsultarNFSe => "PedidoConsultaNFe_v01.xsd",
-            TipoUrl.CancelarNFSe => "PedidoCancelamentoNFe_v01.xsd",
-            TipoUrl.CancelarNFSeLote => "PedidoCancelamentoLote_v01.xsd",
+            TipoUrl.ConsultarNFSeRps => $"PedidoConsultaNFe_{sufixo}.xsd",
+            TipoUrl.ConsultarNFSe => $"PedidoConsultaNFe_{sufixo}.xsd",
+            TipoUrl.CancelarNFSe => $"PedidoCancelamentoNFe_{sufixo}.xsd",
+            TipoUrl.CancelarNFSeLote => $"PedidoCancelamentoLote_{sufixo}.xsd",
             TipoUrl.SubstituirNFSe => "",
             _ => throw new ArgumentOutOfRangeException(nameof(tipo), tipo, null),
         };
@@ -752,6 +945,8 @@ internal sealed class ProviderISSSaoPaulo : ProviderBase
     protected override IServiceClient GetClient(TipoUrl tipo) => new ISSSaoPauloServiceClient(this, tipo);
 
     protected override string GerarCabecalho() => "";
+
+    protected override bool RemoverDeclaracaoXmlAposAssinatura(TipoUrl tipo) => NumeroLayout == 1;
 
     private string GetHashRps(NotaServico nota)
     {

--- a/src/OpenAC.Net.NFSe/Providers/ProviderBase.cs
+++ b/src/OpenAC.Net.NFSe/Providers/ProviderBase.cs
@@ -379,7 +379,8 @@ public abstract class ProviderBase : IOpenLog, IDisposable
             GravarArquivoEmDisco(retornoWebservice.XmlEnvio, $"Enviar-{lote}-env.xml");
 
             //Remover a declaração do Xml se tiver
-            retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
+            if (RemoverDeclaracaoXmlAposAssinatura(TipoUrl.Enviar))
+                retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
 
             // Verifica Schema
             if (PrecisaValidarSchema(TipoUrl.Enviar))
@@ -434,7 +435,8 @@ public abstract class ProviderBase : IOpenLog, IDisposable
         GravarArquivoEmDisco(retornoWebservice.XmlEnvio, $"EnviarSincrono-{lote}-env.xml");
 
         //Remover a declaração do Xml se tiver
-        retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
+        if (RemoverDeclaracaoXmlAposAssinatura(TipoUrl.EnviarSincrono))
+            retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
 
         // Verifica Schema
         if (PrecisaValidarSchema(TipoUrl.EnviarSincrono))
@@ -492,7 +494,8 @@ public abstract class ProviderBase : IOpenLog, IDisposable
             GravarArquivoEmDisco(retornoWebservice.XmlEnvio, $"ConsultarSituacao-{DateTime.Now:yyyyMMddssfff}-{protocolo}-env.xml");
 
             //Remover a declaração do Xml se tiver
-            retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
+            if (RemoverDeclaracaoXmlAposAssinatura(TipoUrl.ConsultarSituacao))
+                retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
 
             // Verifica Schema
             if (PrecisaValidarSchema(TipoUrl.ConsultarSituacao))
@@ -549,7 +552,8 @@ public abstract class ProviderBase : IOpenLog, IDisposable
             GravarArquivoEmDisco(retornoWebservice.XmlEnvio, $"ConsultarLote-{DateTime.Now:yyyyMMddssfff}-{protocolo}-env.xml");
 
             // Remover a declaração do Xml se tiver
-            retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
+            if (RemoverDeclaracaoXmlAposAssinatura(TipoUrl.ConsultarLoteRps))
+                retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
 
             // Verifica Schema
             if (PrecisaValidarSchema(TipoUrl.ConsultarLoteRps))
@@ -603,7 +607,8 @@ public abstract class ProviderBase : IOpenLog, IDisposable
             GravarArquivoEmDisco(retornoWebservice.XmlEnvio, $"ConsultarSequencialRps-{DateTime.Now:yyyyMMddssfff}-{serie}-env.xml");
 
             // Remover a declaração do Xml se tiver
-            retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
+            if (RemoverDeclaracaoXmlAposAssinatura(TipoUrl.ConsultarSequencialRps))
+                retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
 
             // Verifica Schema
             if (PrecisaValidarSchema(TipoUrl.ConsultarSequencialRps))
@@ -666,7 +671,8 @@ public abstract class ProviderBase : IOpenLog, IDisposable
             GravarArquivoEmDisco(retornoWebservice.XmlEnvio, $"ConsultarNFSeRps-{numero}-{serie}-env.xml");
 
             // Remover a declaração do Xml se tiver
-            retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
+            if (RemoverDeclaracaoXmlAposAssinatura(TipoUrl.ConsultarNFSeRps))
+                retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
 
             // Verifica Schema
             if (PrecisaValidarSchema(TipoUrl.ConsultarNFSeRps))
@@ -740,7 +746,8 @@ public abstract class ProviderBase : IOpenLog, IDisposable
             GravarArquivoEmDisco(retornoWebservice.XmlEnvio, $"ConsultarNFSe-{DateTime.Now:yyyyMMddssfff}-{numeroNfse}-env.xml");
 
             // Remover a declaração do Xml se tiver
-            retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
+            if (RemoverDeclaracaoXmlAposAssinatura(TipoUrl.ConsultarNFSe))
+                retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
 
             // Verifica Schema
             if (PrecisaValidarSchema(TipoUrl.ConsultarNFSe))
@@ -800,7 +807,8 @@ public abstract class ProviderBase : IOpenLog, IDisposable
             GravarArquivoEmDisco(retornoWebservice.XmlEnvio, $"CancelarNFSe-{numeroNFSe}-env.xml");
 
             // Remover a declaração do Xml se tiver
-            retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
+            if (RemoverDeclaracaoXmlAposAssinatura(TipoUrl.CancelarNFSe))
+                retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
 
             // Verifica Schema
             if (PrecisaValidarSchema(TipoUrl.CancelarNFSe))
@@ -854,7 +862,8 @@ public abstract class ProviderBase : IOpenLog, IDisposable
             GravarArquivoEmDisco(retornoWebservice.XmlEnvio, $"CancelarNFSeLote-{lote}-env.xml");
 
             // Remover a declaração do Xml se tiver
-            retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
+            if (RemoverDeclaracaoXmlAposAssinatura(TipoUrl.CancelarNFSeLote))
+                retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
 
             // Verifica Schema
             if (PrecisaValidarSchema(TipoUrl.CancelarNFSeLote))
@@ -913,7 +922,8 @@ public abstract class ProviderBase : IOpenLog, IDisposable
             GravarArquivoEmDisco(retornoWebservice.XmlEnvio, $"SubstituirNFSe-{numeroNFSe}-env.xml");
 
             // Remover a declaração do Xml se tiver
-            retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
+            if (RemoverDeclaracaoXmlAposAssinatura(TipoUrl.SubstituirNFSe))
+                retornoWebservice.XmlEnvio = retornoWebservice.XmlEnvio.RemoverDeclaracaoXml();
 
             // Verifica Schema
             if (PrecisaValidarSchema(TipoUrl.SubstituirNFSe))
@@ -1219,6 +1229,11 @@ public abstract class ProviderBase : IOpenLog, IDisposable
     /// <param name="tipo"></param>
     /// <returns></returns>
     protected virtual bool PrecisaValidarSchema(TipoUrl tipo) => true;
+
+    /// <summary>
+    /// Define se a declaração XML deve ser removida depois da assinatura.
+    /// </summary>
+    protected virtual bool RemoverDeclaracaoXmlAposAssinatura(TipoUrl tipo) => true;
 
     /// <summary>
     /// Retornar o XML da assinatura ou nulo caso não tenha nada.

--- a/src/OpenAC.Net.NFSe/Providers/Tiplan/ProviderTiplan203.cs
+++ b/src/OpenAC.Net.NFSe/Providers/Tiplan/ProviderTiplan203.cs
@@ -32,6 +32,7 @@
 using System;
 using System.Linq;
 using System.Xml.Linq;
+using OpenAC.Net.Core;
 using OpenAC.Net.Core.Extensions;
 using OpenAC.Net.DFe.Core;
 using OpenAC.Net.DFe.Core.Serializer;
@@ -84,7 +85,60 @@ internal sealed class ProviderTiplan203 : ProviderABRASF203
         servico.AddChild(AddTag(TipoCampo.Int, "", "MunicipioIncidencia", 7, 7, Ocorrencia.MaiorQueZero, nota.Servico.MunicipioIncidencia));
         servico.AddChild(AddTag(TipoCampo.Str, "", "NumeroProcesso", 1, 30, Ocorrencia.NaoObrigatoria, nota.Servico.NumeroProcesso));
 
+        var ibsCbs = WriteIBSCBS(nota);
+        if (ibsCbs != null)
+            servico.Add(ibsCbs);
+
         return servico;
+    }
+
+    private XElement? WriteIBSCBS(NotaServico nota)
+    {
+        var info = nota.Servico.Valores.IBSCBS;
+        if (info == null)
+            return null;
+
+        var indicadorFinal = info.IndicadorFinal ?? string.Empty;
+        var codigoOperacao = !string.IsNullOrWhiteSpace(info.CodigoIndicadorOperacao)
+            ? info.CodigoIndicadorOperacao
+            : nota.Servico.CodigoIndicadorOperacao;
+        var classificacao = !string.IsNullOrWhiteSpace(info.Valores.Tributos.SituacaoClassificacao.CodigoClassificacaoTributaria)
+            ? info.Valores.Tributos.SituacaoClassificacao.CodigoClassificacaoTributaria
+            : nota.Servico.CodigoClassificacaoTributaria;
+        var situacaoInformada = info.Valores.Tributos.SituacaoClassificacao.CodigoSituacaoTributaria ?? string.Empty;
+
+        var algumInformado = !string.IsNullOrWhiteSpace(indicadorFinal) ||
+                             !string.IsNullOrWhiteSpace(codigoOperacao) ||
+                             !string.IsNullOrWhiteSpace(classificacao) ||
+                             !string.IsNullOrWhiteSpace(situacaoInformada);
+
+        if (!algumInformado)
+            return null;
+
+        if (indicadorFinal is not ("0" or "1"))
+            throw new OpenException("IBS/CBS da Tiplan: OperacaoUsoConsumoPessoal deve ser 0 ou 1.");
+
+        if (!PossuiSomenteDigitos(codigoOperacao, 6))
+            throw new OpenException("IBS/CBS da Tiplan: Operacao (cIndOp) deve conter exatamente 6 dígitos.");
+
+        if (!PossuiSomenteDigitos(classificacao, 6))
+            throw new OpenException("IBS/CBS da Tiplan: ClassificacaoTributaria deve conter exatamente 6 dígitos.");
+
+        var situacao = classificacao.Substring(0, 3);
+        if (!string.IsNullOrWhiteSpace(situacaoInformada) && situacaoInformada != situacao)
+            throw new OpenException("IBS/CBS da Tiplan: SituacaoTributaria deve corresponder aos três primeiros dígitos da ClassificacaoTributaria.");
+
+        return new XElement("IBSCBS",
+            new XElement("OperacaoUsoConsumoPessoal", indicadorFinal),
+            new XElement("Operacao", codigoOperacao),
+            new XElement("ValoresTributos",
+                new XElement("SituacaoTributaria", situacao),
+                new XElement("ClassificacaoTributaria", classificacao)));
+    }
+
+    private static bool PossuiSomenteDigitos(string valor, int tamanho)
+    {
+        return valor?.Length == tamanho && valor.All(c => c >= '0' && c <= '9');
     }
 
     /// <inheritdoc />

--- a/src/OpenAC.Net.NFSe/Resources/Municipios.nfse
+++ b/src/OpenAC.Net.NFSe/Resources/Municipios.nfse
@@ -14366,7 +14366,7 @@
       <UrlHomologacao>
         <Item>
           <TipoUrl>Enviar</TipoUrl>
-          <Url>https://nfe.prefeitura.sp.gov.br/ws/lotenfe.asmx?WSDL</Url>
+          <Url>https://nfews.prefeitura.sp.gov.br/lotenfe.asmx?WSDL</Url>
         </Item>
         <Item>
           <TipoUrl>EnviarSincrono</TipoUrl>
@@ -14402,33 +14402,33 @@
       <UrlProducao>
         <Item>
           <TipoUrl>Enviar</TipoUrl>
-          <Url>https://nfe.prefeitura.sp.gov.br/ws/lotenfe.asmx?WSDL</Url>
+          <Url>https://nfews.prefeitura.sp.gov.br/lotenfe.asmx?WSDL</Url>
         </Item>
         <Item>
           <TipoUrl>EnviarSincrono</TipoUrl>
         </Item>
         <Item>
           <TipoUrl>CancelarNFSe</TipoUrl>
-          <Url>https://nfe.prefeitura.sp.gov.br/ws/lotenfe.asmx?WSDL</Url>
+          <Url>https://nfews.prefeitura.sp.gov.br/lotenfe.asmx?WSDL</Url>
         </Item>
         <Item>
           <TipoUrl>CancelarNFSeLote</TipoUrl>
         </Item>
         <Item>
           <TipoUrl>ConsultarNFSe</TipoUrl>
-          <Url>https://nfe.prefeitura.sp.gov.br/ws/lotenfe.asmx?WSDL</Url>
+          <Url>https://nfews.prefeitura.sp.gov.br/lotenfe.asmx?WSDL</Url>
         </Item>
         <Item>
           <TipoUrl>ConsultarNFSeRps</TipoUrl>
-          <Url>https://nfe.prefeitura.sp.gov.br/ws/lotenfe.asmx?WSDL</Url>
+          <Url>https://nfews.prefeitura.sp.gov.br/lotenfe.asmx?WSDL</Url>
         </Item>
         <Item>
           <TipoUrl>ConsultarLoteRps</TipoUrl>
-          <Url>https://nfe.prefeitura.sp.gov.br/ws/lotenfe.asmx?WSDL</Url>
+          <Url>https://nfews.prefeitura.sp.gov.br/lotenfe.asmx?WSDL</Url>
         </Item>
         <Item>
           <TipoUrl>ConsultarSituacao</TipoUrl>
-          <Url>https://nfe.prefeitura.sp.gov.br/ws/lotenfe.asmx?WSDL</Url>
+          <Url>https://nfews.prefeitura.sp.gov.br/lotenfe.asmx?WSDL</Url>
         </Item>
         <Item>
           <TipoUrl>ConsultarSequencialRps</TipoUrl>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/ConsultaGuia_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/ConsultaGuia_v02.xsd
@@ -1,0 +1,171 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://www.prefeitura.sp.gov.br/nfe"
+            xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+            xmlns:async="http://www.prefeitura.sp.gov.br/nfe/tipos">
+
+    
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFeAsync_v02.xsd" />
+
+    <!--
+    ===========================================================================
+    == ELEMENTOS
+    ===========================================================================
+    -->
+
+    <xsd:element name="PedidoConsultaGuia">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="CPFCNPJRemetente"    type="tipos:tpCPFCNPJ"              minOccurs="1" maxOccurs="1" />
+                <xsd:element name="InscricaoPrestador"  type="tipos:tpInscricaoMunicipal"   minOccurs="1" maxOccurs="1" />
+                <xsd:element name="Incidencia"          type="async:tpIncidencia"           minOccurs="1" maxOccurs="1" />
+                <xsd:element name="Situacao"            type="tns:tpConsultaSituacaoGuias"  minOccurs="1" maxOccurs="1" />
+                <xsd:element name="TipoEmissao"         type="async:tpEmissaoGuia"          minOccurs="0" maxOccurs="1" />                
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+    
+
+    <xsd:element name="RetornoConsultaGuia">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1" />
+                        </xsd:sequence>
+                        <xsd:attribute   name="Versao"  type="tipos:tpVersao" use="required" />
+                    </xsd:complexType>
+                </xsd:element>
+
+                <xsd:element name="Guia" type="tns:tpGuia"          minOccurs="0" maxOccurs="unbounded" />
+                <xsd:element name="Erro" type="async:tpEventoAsync" minOccurs="0" maxOccurs="unbounded" />
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <!--
+    ===========================================================================
+    == TIPOS SIMPLES E DE SUPORTE
+    ===========================================================================
+    -->
+    
+    <xsd:complexType name="tpGuias">
+        <xsd:sequence>
+            <xsd:element name="Guia" type="tns:tpGuia" minOccurs="1" maxOccurs="unbounded"  />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    
+    <xsd:complexType name="tpGuia">
+        <xsd:sequence>
+            <xsd:element name="InscricaoPrestador"  type="tipos:tpInscricaoMunicipal"   minOccurs="1" maxOccurs="1" />
+            <xsd:element name="NumeroGuia"          type="tipos:tpNumero"               minOccurs="0" maxOccurs="1" />
+            <xsd:element name="Incidencia"          type="async:tpIncidencia"           minOccurs="1" maxOccurs="1" />
+            <xsd:element name="ValorTotal"          type="tipos:tpValor"                minOccurs="0" maxOccurs="1" />
+            <xsd:element name="ValorIss"            type="tipos:tpValor"                minOccurs="0" maxOccurs="1" />
+            <xsd:element name="ValorTotalPagamento" type="tipos:tpValor"                minOccurs="0" maxOccurs="1" />
+            <xsd:element name="Status"              type="tns:tpStatusGuia"             minOccurs="0" maxOccurs="1" />
+            <xsd:element name="Situacao"            type="tns:tpConsultaSituacaoGuias"  minOccurs="1" maxOccurs="1" />
+            <xsd:element name="Referencia"          type="async:tpEmissaoGuia"          minOccurs="0" maxOccurs="1" />
+            <xsd:element name="DataEmissao"         type="xsd:date"                     minOccurs="0" maxOccurs="1" />
+            <xsd:element name="DataVencimento"      type="xsd:date"                     minOccurs="0" maxOccurs="1" />
+            <xsd:element name="DataPagamento"       type="xsd:date"                     minOccurs="0" maxOccurs="1" />
+            <xsd:element name="DataQuitacao"        type="xsd:date"                     minOccurs="0" maxOccurs="1" />
+            <xsd:element name="DataCancelamento"    type="xsd:date"                     minOccurs="0" maxOccurs="1" />
+            <xsd:element name="LinhaDigitavel"      type="xsd:string"                   minOccurs="0" maxOccurs="1" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    
+    <xsd:simpleType name="tpConsultaSituacaoGuias">
+        <xsd:restriction base="xsd:int">
+            <xsd:enumeration value="1">
+                <xsd:annotation>
+                    <xsd:documentation>Guias pendentes de pagamento</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="2">
+                <xsd:annotation>
+                    <xsd:documentation>Guias quitadas</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="3">
+                <xsd:annotation>
+                    <xsd:documentation>Guias canceladas</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="4">
+                <xsd:annotation>
+                    <xsd:documentation>Guias pendente de emissao</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="tpStatusGuia">
+        <xsd:simpleContent>
+            <xsd:extension base="tns:tpStatusGuiaEnum">
+                <xsd:attribute name="nome" type="xsd:string" use="optional"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:simpleType name="tpStatusGuiaEnum">
+        <xsd:restriction base="xsd:int">
+            <xsd:enumeration value="0">
+                <xsd:annotation>
+                    <xsd:documentation>Normal</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="1">
+                <xsd:annotation>
+                    <xsd:documentation>Cancelada</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="2">
+                <xsd:annotation>
+                    <xsd:documentation>Quitada</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="3">
+                <xsd:annotation>
+                    <xsd:documentation>Aproveitada</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="4">
+                <xsd:annotation>
+                    <xsd:documentation>Alterada</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="5">
+                <xsd:annotation>
+                    <xsd:documentation>QuitadaPorRDT</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="6">
+                <xsd:annotation>
+                    <xsd:documentation>QuitadaPorSubstituicao</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="7">
+                <xsd:annotation>
+                    <xsd:documentation>QuitadaPorRetificacao</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>
+
+<!--
+Normal                  = 0
+Cancelada               = 1
+Quitada                 = 2
+Aproveitada             = 3
+Alterada                = 4
+QuitadaPorRDT           = 5
+QuitadaPorSubstituicao  = 6
+QuitadaPorRetificacao   = 7
+-->

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/ConsultaSituacaoGuiaAsync_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/ConsultaSituacaoGuiaAsync_v02.xsd
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+            xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+            xmlns:async="http://www.prefeitura.sp.gov.br/nfe/tipos"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFeAsync_v02.xsd" />
+
+
+    <xsd:element name="PedidoConsultaSituacaoGuia">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="NumeroProtocolo" type="async:tpNumeroProtocoloAsync" minOccurs="1" maxOccurs="1">
+                    <xsd:annotation>
+                        <xs:documentation>Número do protocolo da guia.</xs:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+
+    <xsd:element name="RetornoConsultaSituacaoGuia">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xs:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Campo indicativo do sucesso do pedido do serviço.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xsd:element name="Situacao" minOccurs="1" maxOccurs="1">
+                    <xsd:complexType>
+                        <xsd:simpleContent>
+                            <xsd:extension base="xsd:int">
+                                <xsd:attribute name="nome" type="async:tpSituacaoGuia"/>
+                            </xsd:extension>
+                        </xsd:simpleContent>
+                    </xsd:complexType>
+                </xsd:element>
+
+                <xsd:element name="NumeroGuia" type="tipos:tpNumero" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>Número da guia após processamento.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+
+                <xsd:element name="DataRecebimento"   type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="DataProcessamento" type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="ResultadoOperacao" type="xsd:string"   minOccurs="0" maxOccurs="1" />
+
+                <xs:element name="Erro" type="async:tpEventoAsync" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>Elemento que representa a ocorrência de eventos de erro durante o processamento da mensagem XML.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/ConsultaSituacaoLoteAsync_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/ConsultaSituacaoLoteAsync_v02.xsd
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+            xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+            xmlns:async="http://www.prefeitura.sp.gov.br/nfe/tipos"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFeAsync_v02.xsd" />
+
+    
+    <xsd:element name="PedidoConsultaSituacaoLote">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="NumeroProtocolo" type="async:tpNumeroProtocoloAsync" minOccurs="1" maxOccurs="1">
+                    <xsd:annotation>
+                        <xs:documentation>Número do protocolo do lote.</xs:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+
+    <xsd:element name="RetornoConsultaSituacaoLote">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xs:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>Campo indicativo do sucesso do pedido do serviço.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                
+                <xsd:element name="Situacao" minOccurs="1" maxOccurs="1">
+                    <xsd:complexType>
+                        <xsd:simpleContent>
+                            <xsd:extension base="xsd:int">
+                                <xsd:attribute name="nome" type="async:tpSituacaoLote"/>
+                            </xsd:extension>
+                        </xsd:simpleContent>
+                    </xsd:complexType>
+                </xsd:element>
+
+                <xsd:element name="NumeroLote" type="tipos:tpNumero" minOccurs="0" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>Número do lote após processamento.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                
+                <xsd:element name="DataRecebimento"   type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="DataProcessamento" type="xsd:dateTime" minOccurs="0" maxOccurs="1"/>
+                <xsd:element name="ResultadoOperacao" type="xsd:string"   minOccurs="0" maxOccurs="1" />
+                
+                <xs:element name="Erro" type="async:tpEventoAsync" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>Elemento que representa a ocorrência de eventos de erro durante o processamento da mensagem XML.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/EmissaoGuiaAsync_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/EmissaoGuiaAsync_v02.xsd
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="http://www.prefeitura.sp.gov.br/nfe"
+            xmlns:sig="http://www.w3.org/2000/09/xmldsig#"
+            xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+            xmlns:async="http://www.prefeitura.sp.gov.br/nfe/tipos">
+
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFeAsync_v02.xsd" />
+    <xsd:import namespace="http://www.w3.org/2000/09/xmldsig#"        schemaLocation="xmldsig-core-schema_v02.xsd" />
+
+    <xsd:element name="PedidoEmissaoGuiaAsync">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="CPFCNPJRemetente"   type="tipos:tpCPFCNPJ"            minOccurs="1" maxOccurs="1" />
+                <xsd:element name="InscricaoPrestador" type="tipos:tpInscricaoMunicipal" minOccurs="1" maxOccurs="1" />
+                <xsd:element name="TipoEmissaoGuia"    type="async:tpEmissaoGuia"        minOccurs="1" maxOccurs="1" />
+                <xsd:element name="Incidencia"         type="async:tpIncidencia"         minOccurs="1" maxOccurs="1" />
+                <xsd:element name="DataPagamento"      type="xsd:date"                   minOccurs="1" maxOccurs="1" />
+                <xsd:element ref="sig:Signature"       minOccurs="1" maxOccurs="1" />
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:element name="RetornoEmissaoGuiaAsync">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element name="Sucesso"         type="tipos:tpSucesso"              minOccurs="1" maxOccurs="1" />
+                            <xsd:element name="InformacoesGuia" type="async:tpInformacoesGuiaAsync" minOccurs="0" maxOccurs="1" />
+                        </xsd:sequence>
+                        <xsd:attribute   name="Versao"          type="tipos:tpVersao" use="required" />
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element name="Erro" type="async:tpEventoAsync" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoCancelamentoLote_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoCancelamentoLote_v02.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+       xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+       xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+       xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="PedidoCancelamentoLote">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para PEDIDO de cancelamento de lote.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelos prestadores de serviços cancelarem as NFS-e geradas a partir de um lote de RPS.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do pedido de cancelamento de lote.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="NumeroLote" type="tipos:tpNumero" minOccurs ="1" maxOccurs ="1">
+                <xs:annotation>
+                  <xs:documentation>Informe o número do Lote a ser cancelado.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao"  use="required" >
+              <xs:annotation>
+                <xs:documentation>Informe a Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element ref="ds:Signature" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Assinatura digital do CNPJ emissor dos RPS.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoCancelamentoNFe_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoCancelamentoNFe_v02.xsd
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="PedidoCancelamentoNFe">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para PEDIDO de Cancelamento de NFS-e.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelos Prestadores de serviços cancelarem NFS-e emitidas por eles.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do pedido.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1" >
+                <xs:annotation>
+                  <xs:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="transacao" type="xs:boolean" minOccurs="1" maxOccurs="1" default="true">
+                <xs:annotation>
+                  <xs:documentation>Informe se as NFS-e a serem canceladas farão parte de uma mesma transação. True - As NFS-e só serão canceladas se não ocorrer nenhum evento de erro durante o processamento de todo o lote; False - As NFS-e aptas a serem canceladas serão canceladas, mesmo que ocorram eventos de erro durante processamento do cancelamento de outras NFS-e deste lote.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required" >
+              <xs:annotation>
+                <xs:documentation>Informe a Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Detalhe" minOccurs="1" maxOccurs="50">
+          <xs:annotation>
+            <xs:documentation>Detalhe do pedido de cancelamento de NFS-e. Cada detalhe deverá conter a Chave de uma NFS-e e sua respectiva assinatura de cancelamento.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="ChaveNFe" type="tipos:tpChaveNFe" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Chave da NFS-e a ser cancelada.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="AssinaturaCancelamento" type="tipos:tpAssinaturaCancelamento" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Assinatura da NFS-e a ser cancelada.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element ref="ds:Signature"  minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Assinatura digital do CNPJ emissor das NFS-e</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoConsultaCNPJ_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoConsultaCNPJ_v02.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="PedidoConsultaCNPJ">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para PEDIDO de consultas de CNPJ.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelos tomadores e/ou prestadores de serviços consultarem quais Inscrições Municipais (CCM) estão vinculadas a um determinado CNPJ e se estes CCM emitem NFS-e ou não.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do pedido.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1" >
+                <xs:annotation>
+                  <xs:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required" >
+              <xs:annotation>
+                <xs:documentation>Informe a Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="CNPJContribuinte" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Informe o CNPJ do Contribuinte que se deseja consultar.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ds:Signature" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Assinatura digital do CNPJ tomador/prestador que gerou a mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoConsultaLote_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoConsultaLote_v02.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="PedidoConsultaLote">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para PEDIDO de consultas de Lote.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelos prestadores de serviços consultarem as NFS-e geradas a partir de um lote de RPS.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do pedido.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1" >
+                <xs:annotation>
+                  <xs:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="NumeroLote" type="tipos:tpNumero" minOccurs ="1" maxOccurs ="1">
+                <xs:annotation>
+                  <xs:documentation>Informe o número do Lote que deseja consultar.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required" >
+              <xs:annotation>
+                <xs:documentation>Informe a Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element ref="ds:Signature" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Assinatura digital do contribuinte que gerou o lote de RPS.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoConsultaNFePeriodo_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoConsultaNFePeriodo_v02.xsd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="PedidoConsultaNFePeriodo">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para PEDIDO de consulta de NFS-e Emitidas ou Recebidas por período.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelos Prestadores/Tomadores de serviços consultarem NFS-e Emitidas ou Recebidas por eles.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do pedido.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="CPFCNPJ" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Para consulta de NFS-e Recebidas Informe o CNPJ do Tomador.</xs:documentation>
+                  <xs:documentation>Para consulta de NFS-e Emitidas Informe o CNPJ do Prestador.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="Inscricao" type="tipos:tpInscricaoMunicipal" minOccurs ="0" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Para consulta de NFS-e Recebidas Informe a Inscrição Municipal do Tomador.</xs:documentation>
+                  <xs:documentation>Para consulta de NFS-e Emitidas Informe a Inscrição Municipal do Prestador. Neste caso o preenchimento deste campo se torna obrigatório.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="dtInicio" type="xs:date" minOccurs="1" maxOccurs ="1">
+                <xs:annotation>
+                  <xs:documentation>Informe a data de início do período a ser consultado (AAAA-MM-DD).</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="dtFim" type="xs:date" minOccurs="1" maxOccurs ="1">
+                <xs:annotation>
+                  <xs:documentation>Informe a data final do período trasmitido (AAAA-MM-DD).</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="NumeroPagina" type="tipos:tpNumero" minOccurs ="1" maxOccurs ="1" default="1">
+                <xs:annotation>
+                  <xs:documentation>Informe o número da página que deseja consultar.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required" >
+              <xs:annotation>
+                <xs:documentation>Informe a Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element ref="ds:Signature" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Assinatura digital do tomador das NFS-e.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoConsultaNFe_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoConsultaNFe_v02.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="PedidoConsultaNFe">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para PEDIDO de consultas de NFS-e.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelos prestadores de serviços consultarem NFS-e geradas por eles.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do pedido.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1" >
+                <xs:annotation>
+                  <xs:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required" >
+              <xs:annotation>
+                <xs:documentation>Informe a Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Detalhe" minOccurs="1" maxOccurs="50">
+          <xs:annotation>
+            <xs:documentation>Detalhe do pedido. Cada item de detalhe deverá conter a chave de uma NFS-e ou a chave de um RPS.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:choice>
+              <xs:element name="ChaveRPS" type="tipos:tpChaveRPS" minOccurs="1" maxOccurs="1" />
+              <xs:element name="ChaveNFe" type="tipos:tpChaveNFe" minOccurs="1" maxOccurs="1" />
+            </xs:choice>
+          </xs:complexType>
+        </xs:element>
+        <xs:element ref="ds:Signature" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Assinatura digital do contribuinte que gerou as NFS-e/RPS.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoEnvioLoteRPSAsync_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoEnvioLoteRPSAsync_v02.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+	<xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+	<xs:element name="PedidoEnvioLoteRPS">
+		<xs:annotation>
+			<xs:documentation>Schema utilizado para PEDIDO de envio de lote de RPS.</xs:documentation>
+			<xs:documentation>Este Schema XML é utilizado pelos prestadores de serviços para substituição em lote de RPS por NFS-e.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation>Cabeçalho do pedido.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="transacao" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+								<xs:annotation>
+									<xs:documentation>Informe se os RPS a serem substituídos por NFS-e farão parte de uma mesma transação. True - Os RPS só serão substituídos por NFS-e se não ocorrer nenhum evento de erro durante o processamento de todo o lote; False - Os RPS válidos serão substituídos por NFS-e, mesmo que ocorram eventos de erro durante processamento de outros RPS deste lote.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="dtInicio" type="xs:date" minOccurs="1" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation>Informe a data de início do período transmitido (AAAA-MM-DD).</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="dtFim" type="xs:date" minOccurs="1" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation>Informe a data final do período transmitido (AAAA-MM-DD).</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="QtdRPS"  type="tipos:tpQuantidade" minOccurs="1" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation>Informe o total de RPS contidos na mensagem XML.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="Versao" type="tipos:tpVersao" use="required">
+							<xs:annotation>
+								<xs:documentation>Informe a Versão do Schema XML utilizado.</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="RPS" type="tipos:tpRPS" minOccurs="1" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Informe os RPS a serem substituidos por NFS-e.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="ds:Signature" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation>Assinatura digital do contribuinte que gerou os RPS contidos na mensagem XML.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoEnvioLoteRPS_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoEnvioLoteRPS_v02.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+	<xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+	<xs:element name="PedidoEnvioLoteRPS">
+		<xs:annotation>
+			<xs:documentation>Schema utilizado para PEDIDO de envio de lote de RPS.</xs:documentation>
+			<xs:documentation>Este Schema XML é utilizado pelos prestadores de serviços para substituição em lote de RPS por NFS-e.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation>Cabeçalho do pedido.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="transacao" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+								<xs:annotation>
+									<xs:documentation>Informe se os RPS a serem substituídos por NFS-e farão parte de uma mesma transação. True - Os RPS só serão substituídos por NFS-e se não ocorrer nenhum evento de erro durante o processamento de todo o lote; False - Os RPS válidos serão substituídos por NFS-e, mesmo que ocorram eventos de erro durante processamento de outros RPS deste lote.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="dtInicio" type="xs:date" minOccurs="1" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation>Informe a data de início do período transmitido (AAAA-MM-DD).</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="dtFim" type="xs:date" minOccurs="1" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation>Informe a data final do período transmitido (AAAA-MM-DD).</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="QtdRPS"  type="tipos:tpQuantidade" minOccurs="1" maxOccurs="1">
+								<xs:annotation>
+									<xs:documentation>Informe o total de RPS contidos na mensagem XML.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="Versao" type="tipos:tpVersao" use="required">
+							<xs:annotation>
+								<xs:documentation>Informe a Versão do Schema XML utilizado.</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="RPS" type="tipos:tpRPS" minOccurs="1" maxOccurs="50">
+					<xs:annotation>
+						<xs:documentation>Informe os RPS a serem substituidos por NFS-e.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element ref="ds:Signature" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation>Assinatura digital do contribuinte que gerou os RPS contidos na mensagem XML.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoEnvioRPS_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoEnvioRPS_v02.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="PedidoEnvioRPS">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para PEDIDO de envio de RPS.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelos prestadores de serviços para substituição online e individual de RPS por NFS-e.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do pedido.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required">
+              <xs:annotation>
+                <xs:documentation>Informe a Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="RPS" type="tipos:tpRPS" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Informe o RPS a ser substituido por NFS-e.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ds:Signature" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Assinatura digital do contribuinte que gerou o RPS contido da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoInformacoesLote_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/PedidoInformacoesLote_v02.xsd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="PedidoInformacoesLote">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para PEDIDO de informações de lote.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelos prestadores de serviços para obterem informações de lotes de RPS que geraram NFS-e.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do pedido.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1" >
+                <xs:annotation>
+                  <xs:documentation>Informe o CPF/CNPJ do Remetente autorizado a transmitir a mensagem XML.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="NumeroLote" type="tipos:tpNumero" minOccurs ="0" maxOccurs ="1">
+                <xs:annotation>
+                  <xs:documentation>Informe o número do lote que deseja obter informações. Caso não seja informado o número do lote, serão retornadas informações do último lote gerador de NFS-e.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="InscricaoPrestador" type="tipos:tpInscricaoMunicipal" minOccurs ="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Informe a Inscrição municipal do prestador de serviços que gerou o lote.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required" >
+              <xs:annotation>
+                <xs:documentation>Informe a Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element ref="ds:Signature" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Assinatura digital do contribuinte que gerou o lote de RPS.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoCancelamentoNFe_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoCancelamentoNFe_v02.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="RetornoCancelamentoNFe">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para RETORNO de Pedidos de cancelamento de NFS-e.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelo Web Service para informar aos prestadores de serviços qual o resultado do pedido de cancelamento de NFS-e.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do retorno.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Campo indicativo do sucesso do pedido do serviço.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required" >
+              <xs:annotation>
+                <xs:documentation>Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Alerta" type="tipos:tpEvento" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Elemento que representa a ocorrência de eventos de alerta durante o processamento da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="Erro" type="tipos:tpEvento" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Elemento que representa a ocorrência de eventos de erro durante o processamento da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoConsultaCNPJ_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoConsultaCNPJ_v02.xsd
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="RetornoConsultaCNPJ">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para RETORNO de Pedidos de Consultas de CNPJ.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelo Web Service para informar aos tomadores e/ou prestadores de serviços quais Inscrições Municipais (CCM) estão vinculadas a um determinado CNPJ e se estes CCM emitem NFS-e ou não.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do retorno.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Campo indicativo do sucesso do pedido do serviço.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required" >
+              <xs:annotation>
+                <xs:documentation>Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Alerta" type="tipos:tpEvento" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Elemento que representa a ocorrência de eventos de alerta durante o processamento da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="Erro" type="tipos:tpEvento" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Elemento que representa a ocorrência de eventos de erro durante o processamento da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="Detalhe" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="InscricaoMunicipal" type="tipos:tpInscricaoMunicipal" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Inscrição Municipal vinculada ao CNPJ consultado.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="EmiteNFe" type="xs:boolean" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Campo que indica se o CCM vinculado ao CNPJ consultado emite NFS-e ou não.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+          </xs:sequence>            
+          </xs:complexType>            
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoConsulta_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoConsulta_v02.xsd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="RetornoConsulta">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para RETORNO de pedidos de consulta de NFS-e/RPS, consultade NFS-e recebidas e consulta de lote.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelo Web Service para informar aos tomadores e/ou prestadores de serviços o resultado de pedidos de consulta de NFS-e/RPS, consultade NFS-e recebidas e consulta de lote.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do retorno.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Campo indicativo do sucesso do pedido do serviço.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required" >
+              <xs:annotation>
+                <xs:documentation>Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Alerta" type="tipos:tpEvento" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Elemento que representa a ocorrência de eventos de alerta durante o processamento da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="Erro" type="tipos:tpEvento" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Elemento que representa a ocorrência de eventos de erro durante o processamento da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="NFe" type="tipos:tpNFe" minOccurs="0" maxOccurs="50">
+          <xs:annotation>
+            <xs:documentation>Elemento NFe - Cada item será um NFS-e.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoEnvioLoteRPSAsync_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoEnvioLoteRPSAsync_v02.xsd
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema elementFormDefault="unqualified"
+           targetNamespace="http://www.prefeitura.sp.gov.br/nfe"
+           xmlns:tns="http://www.prefeitura.sp.gov.br/nfe"
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+           xmlns:async="http://www.prefeitura.sp.gov.br/nfe/tipos"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+    <xsd:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFeAsync_v02.xsd" />
+    <xsd:import namespace="http://www.w3.org/2000/09/xmldsig#"        schemaLocation="xmldsig-core-schema_v02.xsd" />
+
+    <xsd:element name="RetornoEnvioLoteRPSAsync">
+        <xsd:annotation>
+            <xsd:documentation>Schema utilizado para RETORNO de Pedidos de Envio de lote de RPS Assincrono.</xsd:documentation>
+            <xsd:documentation>Este Schema XML é utilizado pelo Web Service para informar aos prestadores de serviços o resultado do pedido de envio de lote de RPS Assincrono.</xsd:documentation>
+        </xsd:annotation>
+
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>Cabeçalho do retorno.</xsd:documentation>
+                    </xsd:annotation>
+
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1">
+                                <xsd:annotation>
+                                    <xsd:documentation>Campo indicativo do sucesso do pedido do serviço.</xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+
+                            <xsd:element name="InformacoesLote" type="async:tpInformacoesLoteAsync" minOccurs ="0" maxOccurs ="1">
+                                <xsd:annotation>
+                                    <xsd:documentation>Informações sobre o lote processado.</xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                        </xsd:sequence>
+
+                        <xsd:attribute name="Versao" type="tipos:tpVersao" use="required" >
+                            <xsd:annotation>
+                                <xsd:documentation>Versão do Schema XML utilizado.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:attribute>
+                    </xsd:complexType>
+                </xsd:element>
+
+                <xsd:element name="Erro" type="async:tpEventoAsync" minOccurs="0" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation>Elemento que representa a ocorrência de eventos de erro durante o processamento da mensagem XML.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoEnvioLoteRPS_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoEnvioLoteRPS_v02.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="RetornoEnvioLoteRPS">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para RETORNO de Pedidos de Envio de lote de RPS.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelo Web Service para informar aos prestadores de serviços o resultado do pedido de envio de lote de RPS.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do retorno.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Campo indicativo do sucesso do pedido do serviço.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="InformacoesLote" type="tipos:tpInformacoesLote" minOccurs ="0" maxOccurs ="1">
+                <xs:annotation>
+                  <xs:documentation>Informações sobre o lote processado.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required">
+              <xs:annotation>
+                <xs:documentation>Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Alerta" type="tipos:tpEvento" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Elemento que representa a ocorrência de eventos de alerta durante o processamento da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="Erro" type="tipos:tpEvento" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Elemento que representa a ocorrência de eventos de erro durante o processamento da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="ChaveNFeRPS" type="tipos:tpChaveNFeRPS" minOccurs="0" maxOccurs="50">
+          <xs:annotation>
+            <xs:documentation>Chave da NFS-e e Chave do RPS que esta substitui.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoEnvioRPS_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoEnvioRPS_v02.xsd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="RetornoEnvioRPS">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para RETORNO de Pedidos de Envio de RPS.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelo Web Service para informar aos prestadores de serviços o resultado do pedido de envio de RPS.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do retorno.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Campo indicativo do sucesso do pedido do serviço.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required">
+              <xs:annotation>
+                <xs:documentation>Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Alerta" type="tipos:tpEvento" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Elemento que representa a ocorrência de eventos de alerta durante o processamento da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="Erro" type="tipos:tpEvento" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Elemento que representa a ocorrência de eventos de erro durante o processamento da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="ChaveNFeRPS" type="tipos:tpChaveNFeRPS" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Chave da NFS-e e Chave do RPS que esta substitui.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoInformacoesLote_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/RetornoInformacoesLote_v02.xsd
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe" 
+           xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <xs:import namespace="http://www.prefeitura.sp.gov.br/nfe/tipos" schemaLocation="TiposNFe_v02.xsd" />
+  <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+  <xs:element name="RetornoInformacoesLote">
+    <xs:annotation>
+      <xs:documentation>Schema utilizado para RETORNO de Pedidos de Informações de Lote.</xs:documentation>
+      <xs:documentation>Este Schema XML é utilizado pelo Web Service para informar aos prestadores de serviços o resultado do pedido de informações de lote.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Cabecalho" minOccurs="1" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>Cabeçalho do retorno.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Sucesso" type="tipos:tpSucesso" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                  <xs:documentation>Campo indicativo do sucesso do pedido do serviço.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element name="InformacoesLote" type="tipos:tpInformacoesLote" minOccurs ="0" maxOccurs ="1">
+                <xs:annotation>
+                  <xs:documentation>Informações do lote consultado.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="Versao" type="tipos:tpVersao" use="required" >
+              <xs:annotation>
+                <xs:documentation>Versão do Schema XML utilizado.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Alerta" type="tipos:tpEvento" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Elemento que representa a ocorrência de eventos de alerta durante o processamento da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="Erro" type="tipos:tpEvento" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Elemento que representa a ocorrência de eventos de erro durante o processamento da mensagem XML.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/TiposNFeAsync_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/TiposNFeAsync_v02.xsd
@@ -1,0 +1,179 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema elementFormDefault="unqualified"
+           xmlns="http://www.prefeitura.sp.gov.br/nfe/tipos"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.prefeitura.sp.gov.br/nfe/tipos">
+
+    <xsd:include schemaLocation="TiposNFe_v02.xsd"/>
+
+    
+    <xsd:complexType name="tpEventoAsync">
+        <xsd:sequence>
+            <xsd:element name="Codigo" type="tpCodigoEvento" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Código do evento.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Descricao" type="tpDescricaoEvento" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Descrição do evento.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
+
+    <xsd:complexType name="tpInformacoesLoteAsync">
+        <xsd:annotation>
+            <xsd:documentation>Informações do lote processado.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="NumeroProtocolo" type="tpNumeroProtocoloAsync" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Número do protocolo do lote.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+
+            <xsd:element name="DataRecebimento" type="xsd:dateTime" minOccurs="1" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Data/hora de envio do lote.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
+
+    <xsd:complexType name="tpInformacoesGuiaAsync">
+        <xsd:sequence>
+            <xsd:element name="NumeroProtocolo" type="tpNumeroProtocoloAsync" minOccurs="1" maxOccurs="1"/>
+            <xsd:element name="DataRecebimento" type="xsd:dateTime" minOccurs="1" maxOccurs="1"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+
+    <xsd:simpleType name="tpNumeroProtocoloAsync">
+        <xsd:annotation>
+            <xsd:documentation>Tipo do Número de Protocolo.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="32" />
+            <xsd:maxLength value="32" />
+            <xsd:whiteSpace value="collapse" />
+        </xsd:restriction>
+    </xsd:simpleType>
+
+
+    <xsd:simpleType name="tpIncidencia">
+        <xsd:annotation>
+            <xsd:documentation>Incidência no formato YYYY-MM com ano de 1900 até 2099.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:pattern value="^((19|20)\d\d)-(0?[1-9]|1[012])$"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+
+    <!-- TODO: Should I move it to NFE Main types? -->
+    <xsd:simpleType name="tpSituacaoLote">
+        <xsd:annotation>
+            <xsd:documentation>Tipo referente as possíveis situações do lote assíncrono.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="enviado">
+                <xsd:annotation>
+                    <xsd:documentation>Lote enviado (0).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="invalidado">
+                <xsd:annotation>
+                    <xsd:documentation>Lote invalidado (1).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="verificado">
+                <xsd:annotation>
+                    <xsd:documentation>Lote verificado (2).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="processado">
+                <xsd:annotation>
+                    <xsd:documentation>Lote processado (3).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+
+    <xsd:simpleType name="tpSituacaoGuia">
+        <xsd:annotation>
+            <xsd:documentation>Tipo referente as possíveis situações da emissão de guia assíncrona.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="solicitada">
+                <xsd:annotation>
+                    <xsd:documentation>Emissao solicitada (0).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="invalidada">
+                <xsd:annotation>
+                    <xsd:documentation>Emissao invalidada (1).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="verificada">
+                <xsd:annotation>
+                    <xsd:documentation>Emissao verificada (2).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="processada">
+                <xsd:annotation>
+                    <xsd:documentation>Emissao processada (3).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+
+    <xsd:simpleType name="tpEmissaoGuia">
+        <xsd:restriction base="xsd:int">
+            <xsd:enumeration value="1">
+                <xsd:annotation>
+                    <xsd:documentation>Guia de NFS-e emitidas</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="2">
+                <xsd:annotation>
+                    <xsd:documentation>Guia de NFS-e recebidas (exceto rejeitadas)</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="3">
+              <xsd:annotation>
+                <xsd:documentation>Guia de NFS-e Emitidas e Recebidas (exceto rejeitadas)</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="4">
+              <xsd:annotation>
+                <xsd:documentation>Guia de NFS-e recebidas aceitas</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="5">
+              <xsd:annotation>
+                <xsd:documentation>Guia de NFS-e recebidas sem manifestação do tomador</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="6">
+              <xsd:annotation>
+                <xsd:documentation>Guia de NFS-e recebidas rejeitadas</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="7">
+              <xsd:annotation>
+                <xsd:documentation>Guia de NFTS emitidas</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="8">
+              <xsd:annotation>
+                <xsd:documentation>Todas (NFS-e emitidas, NFTS emitidas e NFS-e recebidas, exceto rejeitadas)</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/TiposNFe_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/TiposNFe_v02.xsd
@@ -1,0 +1,2188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema targetNamespace="http://www.prefeitura.sp.gov.br/nfe/tipos"
+    xmlns:tipos="http://www.prefeitura.sp.gov.br/nfe/tipos"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v02.xsd" />
+	<!-- Tipos Simples -->
+	<xs:simpleType name="tpAliquota">
+		<xs:annotation>
+			<xs:documentation>Tipo utilizado para valor de alíquota</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="5" />
+			<xs:fractionDigits value="4" />
+			<xs:minInclusive value="0" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpAssinatura">
+		<xs:annotation>
+			<xs:documentation>Assinatura digital do RPS emitido.</xs:documentation>
+			<xs:documentation>O RPS deverá ser assinado digitalmente. O contribuinte deverá assinar uma cadeia de caracteres (ASCII) com informações do RPS emitido.</xs:documentation>
+			<xs:documentation>O certificado digital utilizado na assinatura de cancelamento deverá ser o mesmo utilizado na assinatura da mensagem XML. A cadeia de caracteres a ser assinada deverá conter 86 posições com as informações apresentadas a seguir:</xs:documentation>
+			<xs:documentation>Inscrição Municipal (CCM) do Prestador com 8 caracteres. Caso o CCM do Prestador tenha menos de 8 caracteres, o mesmo deverá ser completado com zeros à esquerda.</xs:documentation>
+			<xs:documentation>Série do RPS com 5 posições. Caso a Série do RPS tenha menos de 5 caracteres, o mesmo deverá ser completado com espaços em branco à direita.</xs:documentation>
+			<xs:documentation>Número do RPS com 12 posições. Caso o Número do RPS tenha menos de 12 caracteres, o mesmo deverá ser completado com zeros à esquerda.</xs:documentation>
+			<xs:documentation>Data da emissão do RPS no formato AAAAMMDD.</xs:documentation>
+			<xs:documentation>Tipo de Tributação do RPS com uma posição (sendo T: para Tributação no municipio de São Paulo; F: para Tributação fora do municipio de São Paulo; I: para Isento; J: para ISS Suspenso por Decisão Judicial).</xs:documentation>
+			<xs:documentation>Status do RPS com uma posição (sendo N: Normal, C: Cancelado; E: Extraviado).</xs:documentation>
+			<xs:documentation>ISS Retido com uma posição (sendo S: ISS Retido; N: Nota Fiscal sem ISS Retido).</xs:documentation>
+			<xs:documentation>Valor dos Serviços com 15 posições e sem separador de milhar e decimal.</xs:documentation>
+			<xs:documentation>Valor das Deduções com 15 posições e sem separador de milhar e decimal.</xs:documentation>
+			<xs:documentation>Código do Serviço com 5 posições.</xs:documentation>
+			<xs:documentation>CPF/CNPJ do tomador com 14 posições. Sem formatação (ponto, traço, barra, ....). Completar com zeros à esquerda caso seja necessário. Se o Indicador do CPF/CNPJ for 3 (não-informado), preencher com 14 zeros.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:base64Binary">
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpAssinaturaCancelamento">
+		<xs:annotation>
+			<xs:documentation>Assinatura digital de cancelamento da NFS-e.</xs:documentation>
+			<xs:documentation>Cada NFS-e a ser cancelada deverá ter sua respectiva assinatura de cancelamento. O contribuinte deverá assinar uma cadeia de caracteres (ASCII) com informações da NFS-e a ser cancelada.</xs:documentation>
+			<xs:documentation>O certificado digital utilizado na assinatura de cancelamento deverá ser o mesmo utilizado na assinatura da mensagem XML. A cadeia de caracteres a ser assinada deverá conter 20 posições com as informações apresentadas a seguir:</xs:documentation>
+			<xs:documentation>Inscrição Municipal (CCM) do Prestador com 8 caracteres. Caso o CCM do Prestador tenha menos de 8 caracteres, o mesmo deverá ser completado com zeros à esquerda.</xs:documentation>
+			<xs:documentation>Número da NFS-e RPS com 12 posições. Caso o Número da NFS-e tenha menos de 12 caracteres, o mesmo deverá ser completado com zeros à esquerda.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:base64Binary">
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpBairro">
+		<xs:annotation>
+			<xs:documentation>Tipo bairro.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="0" />
+			<xs:maxLength value="30" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCCIB">
+		<xs:annotation>
+			<xs:documentation>Cadastro de imóveis. Obrigatório para construção civil.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9A-Z]{8}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpClassificacaoTributaria">
+		<xs:annotation>
+			<xs:documentation>Tipo do código de classificação Tributária do IBS e da CBS.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{6}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCEP">
+		<xs:annotation>
+			<xs:documentation>Tipo CEP.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:int">
+			<xs:pattern value="[0-9]{7,8}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCidade">
+		<xs:annotation>
+			<xs:documentation>Tipo Código do Município segundo tabela IBGE.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:int">
+			<xs:pattern value="[0-9]{7}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpChaveNotaNacional">
+		<xs:annotation>
+			<xs:documentation>Tipo da chave da Nota Nacional.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9A-Z]{50}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCNPJ">
+		<xs:annotation>
+			<xs:documentation>Tipo CNPJ.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9A-Z]{12}[0-9]{2}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCodigoServico">
+		<xs:annotation>
+			<xs:documentation>Tipo código de serviço.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:int">
+			<xs:pattern value="[0-9]{4,5}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCodigoEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo código de evento.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:short">
+			<xs:pattern value="[0-9]{3,4}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCodigoEndPostal">
+		<xs:annotation>
+			<xs:documentation>Código de endereçamento postal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="collapse"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="11"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCodigoNBS">
+		<xs:annotation>
+			<xs:documentation>Código da lista de Nomenclatura Brasileira de Serviços (NBS).</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{9}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCodigoNCM">
+		<xs:annotation>
+			<xs:documentation>Código da lista de Nomenclatura Comum do Mercosul (NCM).</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{8}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCodigoPaisISO">
+		<xs:annotation>
+			<xs:documentation>Tipo Código do País segundo tabela ISO.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCodigoVerificacao">
+		<xs:annotation>
+			<xs:documentation>Tipo Código de verificação da NFS-e.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="8" />
+			<xs:maxLength value="8" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpComplementoEndereco">
+		<xs:annotation>
+			<xs:documentation>Tipo complemento do endereço.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="0" />
+			<xs:maxLength value="30" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpEnteGov">
+		<xs:annotation>
+			<xs:documentation>Tipo do ente da compra governamental.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:int">
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>União.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>Estados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>Distrito Federal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>Municípios.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCPF">
+		<xs:annotation>
+			<xs:documentation>Tipo CPF.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{0}|[0-9]{11}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpDescricaoEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo descrição do evento.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="0" />
+			<xs:maxLength value="300" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpDiscriminacao">
+		<xs:annotation>
+			<xs:documentation>Tipo Discriminação Serviços.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1" />
+			<xs:maxLength value="2000" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpEmail">
+		<xs:annotation>
+			<xs:documentation>Tipo E-mail.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="0" />
+			<xs:maxLength value="75" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpEstadoProvinciaRegiao">
+		<xs:annotation>
+			<xs:documentation>Estado, província ou região</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="collapse"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="60"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpFonteCargaTributaria">
+		<xs:annotation>
+			<xs:documentation>Tipo utilizado para a fonte da carga tributária.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="0" />
+			<xs:maxLength value="10" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpInscricaoEstadual">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:long">
+			<xs:pattern value="[0-9]{1,19}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpInscricaoMunicipal">
+		<xs:annotation>
+			<xs:documentation>Tipo padrão referente a inscrição municipal.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:long">
+			<xs:pattern value="[0-9]{1,12}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpLogradouro">
+		<xs:annotation>
+			<xs:documentation>Endereço.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="0" />
+			<xs:maxLength value="50" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpNaoNIF">
+		<xs:annotation>
+			<xs:documentation>Tipo do motivo para não informação do NIF.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:int">
+			<xs:enumeration value="0">
+				<xs:annotation>
+					<xs:documentation>0 - Não informado na nota de origem;</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>1 - Dispensado do NIF;</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>2 - Não exigência do NIF;</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpNaoSim">
+		<xs:annotation>
+			<xs:documentation>Tipo de Não ou Sim.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:int">
+			<xs:pattern value="[01]{1}" />
+			<xs:enumeration value="0">
+				<xs:annotation>
+					<xs:documentation>Não.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>Sim.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpNIF">
+		<xs:annotation>
+			<xs:documentation>Tipo NIF (Número de Identificação Fiscal) - fornecido por um órgão de administração tributária no exterior.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1" />
+			<xs:maxLength value="40" />
+			<xs:whiteSpace value="collapse"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpNomeCidade">
+		<xs:annotation>
+			<xs:documentation>Nome da Cidade</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="collapse"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="60"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpNumero">
+		<xs:annotation>
+			<xs:documentation>Tipo número.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:long">
+			<xs:pattern value="[0-9]{1,12}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpNumeroEndereco">
+		<xs:annotation>
+			<xs:documentation>Tipo número do endereço.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="0" />
+			<xs:maxLength value="10" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpOpcaoSimples">
+		<xs:annotation>
+			<xs:documentation>Tipo referente às possíveis opções de escolha pelo Simples.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="0">
+				<xs:annotation>
+					<xs:documentation>Não-optante pelo Simples Federal nem Municipal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>Optante pelo Simples Federal (Alíquota de 1,0%).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>Optante pelo Simples Federal (Alíquota de 0,5%).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>Optante pelo Simples Municipal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>Optante pelo Simples Nacional - DAS.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="6">
+				<xs:annotation>
+					<xs:documentation>Optante pelo Simples Nacional - DAMSP.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpPercentualCargaTributaria">
+		<xs:annotation>
+			<xs:documentation>Tipo utilizado para o valor do percentual da carga tributária.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="7" />
+			<xs:fractionDigits value="4" />
+			<xs:minInclusive value="0" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpQuantidade">
+		<xs:annotation>
+			<xs:documentation>Tipo padrão para quantidades.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:long">
+			<xs:pattern value="[0-9]{1,15}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpRazaoSocialObrigatorio">
+		<xs:annotation>
+			<xs:documentation>Tipo Razão Social.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1" />
+			<xs:maxLength value="75" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpRazaoSocial">
+		<xs:annotation>
+			<xs:documentation>Tipo Razão Social.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="0" />
+			<xs:maxLength value="75" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpReferencia">
+		<xs:annotation>
+			<xs:documentation>Tipo de referência da nota.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="0">
+				<xs:annotation>
+					<xs:documentation>Nota fiscal referenciada para emissão de nota de multa e juros.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>Nota fiscal de pagamento parcelado antecipado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpSerieRPS">
+		<xs:annotation>
+			<xs:documentation>Tipo série de documento.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1" />
+			<xs:maxLength value="5" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpStatusNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo referente aos possíveis status de NFS-e.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="N">
+				<xs:annotation>
+					<xs:documentation>Normal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="C">
+				<xs:annotation>
+					<xs:documentation>Cancelada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E">
+				<xs:annotation>
+					<xs:documentation>Extraviada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpSucesso">
+		<xs:annotation>
+			<xs:documentation>Tipo que indica se o pedido do serviço obteve sucesso.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:boolean">
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpTempoProcessamento">
+		<xs:annotation>
+			<xs:documentation>Tipo referente ao tempo de processamento do lote.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:long">
+			<xs:pattern value="[0-9]{1,15}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpTipoLogradouro">
+		<xs:annotation>
+			<xs:documentation>Tipo do endereço (Rua, Av, ...).</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="0" />
+			<xs:maxLength value="3" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpTipoNotaReferenciada">
+		<xs:annotation>
+			<xs:documentation>Tipo de nota fiscal referenciada.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="0">
+				<xs:annotation>
+					<xs:documentation>NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>NFTS.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpTipoRPS">
+		<xs:annotation>
+			<xs:documentation>Tipo referente aos possíveis tipos de RPS.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="RPS">
+				<xs:annotation>
+					<xs:documentation>Recibo Provisório de Serviços.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RPS-M">
+				<xs:annotation>
+					<xs:documentation>Recibo Provisório de Serviços proveniente de Nota Fiscal Conjugada (Mista).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RPS-C">
+				<xs:annotation>
+					<xs:documentation>Cupom.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpTributacaoNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo referente aos modos de tributação da NFe.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1" />
+			<xs:maxLength value="1" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpUF">
+		<xs:annotation>
+			<xs:documentation>Tipo UF.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="2" />
+			<xs:maxLength value="2" />
+			<xs:whiteSpace value="collapse" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpValor">
+		<xs:annotation>
+			<xs:documentation>Tipo utilizado para valores com 15 dígitos, sendo 13 de corpo e 2 decimais.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="15" />
+			<xs:fractionDigits value="2" />
+			<xs:minInclusive value="0" />
+			<xs:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{0,2})?" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpVersao">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Schema.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:long">
+			<xs:pattern value="[0-9]{1,3}" />
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpFinNFSe">
+		<xs:annotation>
+			<xs:documentation>Indicador da finalidade da emissão de NFS-e.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:int">
+			<xs:enumeration value="0">
+				<xs:annotation>
+					<xs:documentation>0 = NFS-e regular.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCIndOp">
+		<xs:annotation>
+			<xs:documentation>Código indicador da operação.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{6}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpOper">
+		<xs:annotation>
+			<xs:documentation>Tipo de Operação com Entes Governamentais ou outros serviços sobre bens imóveis.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:int">
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>Fornecimento com pagamento posterior.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>Recebimento do pagamento com fornecimento já realizado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>Fornecimento com pagamento já realizado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>Recebimento do pagamento com fornecimento posterior.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="5">
+				<xs:annotation>
+					<xs:documentation>Fornecimento e recebimento do pagamento concomitantes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpIndDest">
+		<xs:annotation>
+			<xs:documentation>Indica o Destinatário dos serviços.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:int">
+			<xs:enumeration value="0">
+				<xs:annotation>
+					<xs:documentation>O destinatário é o próprio tomador/adquirente identificado na NFS-e (tomador = adquirente = destinatário).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador (tomador = adquirente ≠ destinatário).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpCObra">
+		<xs:annotation>
+			<xs:documentation>Identificação da obra, do Cadastro Nacional de Obras, ou do Cadastro Específico do INSS.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="collapse"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="30"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpInscImobFisc">
+		<xs:annotation>
+			<xs:documentation>Inscrição Imobiliária fiscal (código fornecido pela prefeitura para identificação da obra ou para fins de recolhimento do IPTU). Exemplos: SQL ou INCRA.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="collapse"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="30"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpTipoChaveDFE">
+		<xs:annotation>
+			<xs:documentation>Documento fiscal a que se refere a chaveDfe que seja um dos documentos do Repositório Nacional:</xs:documentation>
+			<xs:documentation>1 - NFS-e.</xs:documentation>
+			<xs:documentation>2 - NF-e.</xs:documentation>
+			<xs:documentation>3 - CT-e.</xs:documentation>
+			<xs:documentation>9 - Outro.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:int">
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>NF-e.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>CT-e.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="9">
+				<xs:annotation>
+					<xs:documentation>Outro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpXTipoChaveDFe">
+		<xs:annotation>
+			<xs:documentation>Descrição da DF -e a que se refere a chaveDfe que seja um dos documentos do Repositório Nacional. Deve ser preenchido apenas quando tipoChaveDFe = 9 (Outro).</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="collapse"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="255"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpChaveDFe">
+		<xs:annotation>
+			<xs:documentation>Chave do Documento Fiscal eletrônico do repositório nacional referenciado para os casos de operações já tributadas.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="collapse"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="50"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpNumeroDescricaoDocumento">
+		<xs:annotation>
+			<xs:documentation>Tipo para o número e descrição de documentos, fiscais ou não.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="collapse"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="255"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpReeRepRes">
+		<xs:annotation>
+			<xs:documentation>Tipo de valor incluído neste documento, recebido por motivo de estarem relacionadas a operações de terceiros, objeto de reembolso, repasse ou ressarcimento pelo recebedor, já tributados e aqui referenciados.</xs:documentation>
+			<xs:documentation>01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação.</xs:documentation>
+			<xs:documentation>02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.</xs:documentation>
+			<xs:documentation>03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.</xs:documentation>
+			<xs:documentation>04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.</xs:documentation>
+			<xs:documentation>99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:int">
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>01 = Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>02 = Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>03 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de produção externa por conta e ordem de terceiro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>04 = Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por valores pagos relativos a serviços de mídia por conta e ordem de terceiro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="99">
+				<xs:annotation>
+					<xs:documentation>99 = Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpXTpReeRepRes">
+		<xs:annotation>
+			<xs:documentation>Descrição do reembolso ou ressarcimento quando a opção é 99 - Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="collapse"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="150"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="tpXNomeEvt">
+		<xs:annotation>
+			<xs:documentation>Tipo Nome do evento cultural, artístico, esportivo.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="collapse"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="255"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- Grupos -->
+	<xs:group name="gpCPFCNPJNIF">
+		<xs:annotation>
+			<xs:documentation>Grupo que representa um CPF/CNPJ/NIF.</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="CPF" type="tipos:tpCPF" minOccurs="1" maxOccurs="1" />
+			<xs:element name="CNPJ" type="tipos:tpCNPJ" minOccurs="1" maxOccurs="1" />
+			<xs:element name="NIF" type="tipos:tpNIF" minOccurs="1" maxOccurs="1" />
+			<xs:element name="NaoNIF" type="tipos:tpNaoNIF" minOccurs="1" maxOccurs="1" />
+		</xs:choice>
+	</xs:group>
+	<xs:group name="gpEnderecoBaseIBSCBS">
+		<xs:annotation>
+			<xs:documentation>Grupo do endereço base do IBSCBS.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr" type="tipos:tpLogradouro" minOccurs="1" maxOccurs="1" />
+			<xs:element name="nro" type="tipos:tpNumeroEndereco" minOccurs="1" maxOccurs="1" />
+			<xs:element name="xCpl" type="tipos:tpComplementoEndereco" minOccurs="0" maxOccurs="1" />
+			<xs:element name="xBairro" type="tipos:tpBairro" minOccurs="1" maxOccurs="1" />
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="gpPrestacao">
+		<xs:annotation>
+			<xs:documentation>Grupo do local de prestação do serviço.</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="cLocPrestacao" type="tipos:tpCidade" minOccurs="1" maxOccurs="1" />
+			<xs:element name="cPaisPrestacao" type="tipos:tpCodigoPaisISO" minOccurs="1" maxOccurs="1" />
+		</xs:choice>
+	</xs:group>
+	<xs:simpleType name="tpRetencaoPisCofins">
+		<xs:annotation>
+			<xs:documentation>Tipo de retenção para os tributos federais conforme numerados.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="0">
+				<xs:annotation>
+					<xs:documentation>PIS/COFINS/CSLL Não Retidos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>PIS/COFINS/CSLL Retidos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>PIS/COFINS Retidos, CSLL Não Retido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="5">
+				<xs:annotation>
+					<xs:documentation>PIS Retido, COFINS/CSLL Não Retido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="6">
+				<xs:annotation>
+					<xs:documentation>COFINS Retido, PIS/CSLL Não Retidos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="7">
+				<xs:annotation>
+					<xs:documentation>PIS Não Retido, COFINS/CSLL Retidos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="8">
+				<xs:annotation>
+					<xs:documentation>PIS/COFINS Não Retidos, CSLL Retido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="9">
+				<xs:annotation>
+					<xs:documentation>COFINS Não Retido, PIS/CSLL Retidos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- Tipos Complexos -->
+	<xs:complexType name="tpEvento">
+		<xs:sequence>
+			<xs:element name="Codigo" type="tipos:tpCodigoEvento" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código do evento.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Descricao" type="tipos:tpDescricaoEvento" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Descrição do evento.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs ="0" maxOccurs ="1">
+				<xs:annotation>
+					<xs:documentation>Chave para identificação da origem do evento.</xs:documentation>
+				</xs:annotation>
+				<xs:element name="ChaveRPS" type="tipos:tpChaveRPS" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation>Chave do RPS.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="ChaveNFe" type="tipos:tpChaveNFe" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation>Chave da NFe.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpCPFCNPJ">
+		<xs:annotation>
+			<xs:documentation>Tipo que representa um CPF/CNPJ.</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="CPF" type="tipos:tpCPF" minOccurs="1" maxOccurs="1" />
+			<xs:element name="CNPJ" type="tipos:tpCNPJ" minOccurs="1" maxOccurs="1" />
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="tpCPFCNPJNIF">
+		<xs:annotation>
+			<xs:documentation>Tipo que representa um CPF/CNPJ/NIF.</xs:documentation>
+		</xs:annotation>
+		<xs:group ref="tipos:gpCPFCNPJNIF" />
+	</xs:complexType>
+	<xs:complexType name="tpChaveNFeRPS">
+		<xs:annotation>
+			<xs:documentation>Tipo que representa a chave de uma NFS-e e a Chave do RPS que a mesma substitui.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ChaveNFe" type ="tipos:tpChaveNFe" minOccurs ="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Chave da NFS-e gerada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ChaveRPS" type ="tipos:tpChaveRPS" minOccurs ="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Chave do RPS substituído.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpChaveNFe">
+		<xs:annotation>
+			<xs:documentation>Chave de identificação da NFS-e.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="InscricaoPrestador" type="tipos:tpInscricaoMunicipal" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Inscrição municipal do prestador de serviços.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NumeroNFe" type="tipos:tpNumero" minOccurs ="1" maxOccurs ="1">
+				<xs:annotation>
+					<xs:documentation>Número da NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CodigoVerificacao" type="tipos:tpCodigoVerificacao" minOccurs ="0" maxOccurs ="1">
+				<xs:annotation>
+					<xs:documentation>Código de verificação da NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ChaveNotaNacional" type="tipos:tpChaveNotaNacional" minOccurs ="0" maxOccurs ="1">
+				<xs:annotation>
+					<xs:documentation>Chave da Nota Nacional.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpChaveRPS">
+		<xs:annotation>
+			<xs:documentation>Tipo que define a chave identificadora de um RPS.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="InscricaoPrestador" type="tipos:tpInscricaoMunicipal" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Inscrição municipal do prestador de serviços.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SerieRPS" type="tipos:tpSerieRPS" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Série do RPS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NumeroRPS" type="tipos:tpNumero" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Número do RPS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpEnderecoExterior">
+		<xs:annotation>
+			<xs:documentation>Tipo endereço no exterior.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="cPais" type="tipos:tpCodigoPaisISO" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código do país (Tabela de Países ISO).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cEndPost" type="tipos:tpCodigoEndPostal" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código alfanumérico do Endereçamento Postal no exterior do prestador do serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xCidade" type="tipos:tpNomeCidade" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Nome da cidade no exterior do prestador do serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xEstProvReg" type="tipos:tpEstadoProvinciaRegiao" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Estado, província ou região da cidade no exterior do prestador do serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpEnderecoNacional">
+		<xs:annotation>
+			<xs:documentation>Tipo endereço no nacional.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="cMun" type="tipos:tpCidade" minOccurs="1" maxOccurs="1" />
+			<xs:element name="CEP" type="tipos:tpCEP" minOccurs="1" maxOccurs="1" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpEndereco">
+		<xs:annotation>
+			<xs:documentation>Tipo Endereço.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="TipoLogradouro" type="tipos:tpTipoLogradouro" minOccurs="0" maxOccurs="1" />
+			<xs:element name="Logradouro" type="tipos:tpLogradouro" minOccurs="0" maxOccurs="1" />
+			<xs:element name="NumeroEndereco" type="tipos:tpNumeroEndereco" minOccurs="0" maxOccurs="1" />
+			<xs:element name="ComplementoEndereco" type="tipos:tpComplementoEndereco" minOccurs="0" maxOccurs="1" />
+			<xs:element name="Bairro" type="tipos:tpBairro" minOccurs="0" maxOccurs="1" />
+			<xs:element name="Cidade" type="tipos:tpCidade" minOccurs="0" maxOccurs="1" />
+			<xs:element name="UF" type="tipos:tpUF" minOccurs="0" maxOccurs="1" />
+			<xs:element name="CEP" type="tipos:tpCEP" minOccurs="0" maxOccurs="1" />
+			<xs:element name="EnderecoExterior" type="tipos:tpEnderecoExterior" minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpEnderecoIBSCBS">
+		<xs:annotation>
+			<xs:documentation>Tipo Endereço para o IBSCBS.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="endNac" type="tipos:tpEnderecoNacional" minOccurs="1" maxOccurs="1" />
+				<xs:element name="endExt" type="tipos:tpEnderecoExterior" minOccurs="1" maxOccurs="1" />
+			</xs:choice>
+			<xs:group ref="tipos:gpEnderecoBaseIBSCBS" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpEnderecoSimplesIBSCBS">
+		<xs:annotation>
+			<xs:documentation>Tipo Endereço simplificado para o IBSCBS.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="CEP" type="tipos:tpCEP" minOccurs="1" maxOccurs="1" />
+				<xs:element name="endExt" type="tipos:tpEnderecoExterior" minOccurs="1" maxOccurs="1" />
+			</xs:choice>
+			<xs:group ref="tipos:gpEnderecoBaseIBSCBS" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpInformacoesLote">
+		<xs:annotation>
+			<xs:documentation>Informações do lote processado.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="NumeroLote" type="tipos:tpNumero" minOccurs ="0" maxOccurs ="1">
+				<xs:annotation>
+					<xs:documentation>Número de lote.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="InscricaoPrestador" type="tipos:tpInscricaoMunicipal" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Inscrição municipal do prestador dos RPS contidos no lote.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CPFCNPJRemetente" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>CNPJ do remetente autorizado a transmitir a mensagem XML.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DataEnvioLote" type="xs:dateTime" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Data/hora de envio do lote.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="QtdNotasProcessadas" type="tipos:tpQuantidade" minOccurs ="1" maxOccurs ="1">
+				<xs:annotation>
+					<xs:documentation>Quantidade de RPS do lote.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TempoProcessamento" type="tipos:tpTempoProcessamento" minOccurs ="1" maxOccurs ="1">
+				<xs:annotation>
+					<xs:documentation>Tempo de processamento do lote.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorTotalServicos" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor total dos serviços dos RPS contidos na mensagem XML.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorTotalDeducoes" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor total das deduções dos RPS contidos na mensagem XML.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpInformacoesPessoa">
+		<xs:annotation>
+			<xs:documentation>Tipo de informações de pessoa.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="tipos:gpCPFCNPJNIF" />
+			<xs:element name="xNome" type="tipos:tpRazaoSocialObrigatorio" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Nome.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="end" type="tipos:tpEnderecoIBSCBS" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Endereço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="email" type="tipos:tpEmail" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Endereço eletrônico.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpGRefNFSe">
+		<xs:annotation>
+			<xs:documentation>Grupo com Ids da nota nacional referenciadas, associadas a NFSE.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="refNFSe" type="tipos:tpChaveNotaNacional" minOccurs="1" maxOccurs="99" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpGrupoReeRepRes">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações relativas a valores incluídos neste documento e recebidos por </xs:documentation>
+			<xs:documentation>motivo de estarem relacionadas a operações de terceiros, objeto de reembolso, repasse ou </xs:documentation>
+			<xs:documentation>ressarcimento pelo recebedor, já tributados e aqui referenciados.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="documentos" type="tipos:tpDocumento" minOccurs="1" maxOccurs="100" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpImovelObra">
+		<xs:annotation>
+			<xs:documentation>Tipo de imovel/obra.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="inscImobFisc" type="tipos:tpInscImobFisc" minOccurs="0" maxOccurs="1" />
+			<xs:choice>
+				<xs:element name="cCIB" type="tipos:tpCCIB" minOccurs="1" maxOccurs="1" />
+				<xs:element name="cObra" type="tipos:tpCObra" minOccurs="1" maxOccurs="1" />
+				<xs:element name="end" type="tipos:tpEnderecoSimplesIBSCBS" minOccurs="1" maxOccurs="1" />
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpDocumento">
+		<xs:annotation>
+			<xs:documentation>Tipo de documento referenciado nos casos de reembolso, repasse e ressarcimento que serão considerados na base de cálculo do ISSQN, do IBS e da CBS.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="dFeNacional" type="tipos:tpDFeNacional" minOccurs="1" maxOccurs="1" />
+				<xs:element name="docFiscalOutro" type="tipos:tpDocFiscalOutro" minOccurs="1" maxOccurs="1" />
+				<xs:element name="docOutro" type="tipos:tpDocOutro" minOccurs="1" maxOccurs="1" />
+			</xs:choice>
+			<xs:element name="fornec" type="tipos:tpFornecedor" minOccurs="0" maxOccurs="1" />
+			<xs:element name="dtEmiDoc" type="xs:date" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Data da emissão do documento dedutível. Ano, mês e dia (AAAA-MM-DD).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dtCompDoc" type="xs:date" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Data da competência do documento dedutível. Ano, mês e dia (AAAA-MM-DD).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tpReeRepRes" type="tipos:tpReeRepRes" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Tipo de valor incluído neste documento, recebido por motivo de estarem relacionadas a operações de </xs:documentation>
+					<xs:documentation>terceiros, objeto de reembolso, repasse ou ressarcimento pelo recebedor, já tributados e aqui referenciado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xTpReeRepRes" type="tipos:tpXTpReeRepRes" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Descrição do reembolso ou ressarcimento quando a opção é </xs:documentation>
+					<xs:documentation>"99 - Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a operações por conta e ordem de terceiro"</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vlrReeRepRes" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor monetário (total ou parcial, conforme documento informado) utilizado para não inclusão na base de cálculo do ISS e do IBS e da CBS da NFS-e que está sendo emitida (R$).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpDFeNacional">
+		<xs:annotation>
+			<xs:documentation>Tipo de documento do repositório nacional.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tipoChaveDFe" type="tipos:tpTipoChaveDFE" minOccurs="1" maxOccurs="1" />
+			<xs:element name="xTipoChaveDFe" type="tipos:tpXTipoChaveDFe" minOccurs="0" maxOccurs="1" />
+			<xs:element name="chaveDFe" type="tipos:tpChaveDFe" minOccurs="1" maxOccurs="1" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpDocFiscalOutro">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de documento fiscais, eletrônicos ou não, que não se encontram no repositório nacional.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="cMunDocFiscal" type="tipos:tpCidade" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código do município emissor do documento fiscal que não se encontra no repositório nacional.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="nDocFiscal" type="tipos:tpNumeroDescricaoDocumento" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Número do documento fiscal que não se encontra no repositório nacional.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xDocFiscal" type="tipos:tpNumeroDescricaoDocumento" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Descrição do documento fiscal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpDocOutro">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de documento não fiscal.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="nDoc" type="tipos:tpNumeroDescricaoDocumento" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Número do documento não fiscal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xDoc" type="tipos:tpNumeroDescricaoDocumento" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Descrição do documento não fiscal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpFornecedor">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações do fornecedor do documento referenciado.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="tipos:gpCPFCNPJNIF" />
+			<xs:element name="xNome" type="tipos:tpRazaoSocialObrigatorio" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Nome do fornecedor.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpAtividadeEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo de informações relativas à atividades de eventos.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xNomeEvt" type="tipos:tpXNomeEvt" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Nome do evento cultural, artístico, esportivo.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dtIniEvt" type="xs:date" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Data de início da atividade de evento. Ano, Mês e Dia (AAAA-MM-DD).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dtFimEvt" type="xs:date" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Data de fim da atividade de evento. Ano, Mês e Dia (AAAA-MM-DD).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="end" type="tipos:tpEnderecoSimplesIBSCBS" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Endereço do Evento.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpIBSCBS">
+		<xs:annotation>
+			<xs:documentation>Tipo das informações do IBS/CBS.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="finNFSe" type="tipos:tpFinNFSe" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Indicador da finalidade da emissão de NFS-e.</xs:documentation>
+					<xs:documentation>0 = NFS-e regular.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="indFinal" type="tipos:tpNaoSim" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Indica operação de uso ou consumo pessoal. (0-Não ou 1-Sim).</xs:documentation>
+					<xs:documentation>0 - Não.</xs:documentation>
+					<xs:documentation>1 - Sim.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cIndOp" type="tipos:tpCIndOp" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código indicador da operação de fornecimento, conforme tabela "código indicador de operação".</xs:documentation>
+					<xs:documentation>Referente à tabela de indicador da operação publicada no ANEXO AnexoVII-IndOp_IBSCBS_V1.00.00-.xlsx.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tpOper" type="tipos:tpOper" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Tipo de Operação com Entes Governamentais ou outros serviços sobre bens imóveis.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gRefNFSe" type="tipos:tpGRefNFSe" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Grupo de NFS-e referenciadas.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tpEnteGov" type="tipos:tpEnteGov" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Tipo do ente da compra governamental.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="indDest" type="tipos:tpIndDest" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Indica o Destinatário dos serviços.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dest" type="tipos:tpInformacoesPessoa" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Destinatário.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="valores" type="tipos:tpValores" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informações relacionadas aos valores do serviço prestado para IBS e à CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="imovelobra" type="tipos:tpImovelObra" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informações sobre o Tipo de Imóvel/Obra.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpGIBSCBS">
+		<xs:annotation>
+			<xs:documentation>Informações relacionadas ao IBS e à CBS.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="cClassTrib" type="tipos:tpClassificacaoTributaria" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código de classificação Tributária do IBS e da CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gTribRegular" type="tipos:tpGTribRegular" minOccurs="0" maxOccurs="1" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpGTribRegular">
+		<xs:annotation>
+			<xs:documentation>Informações relacionadas à tributação regular.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="cClassTribReg" type="tipos:tpClassificacaoTributaria" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código de classificação Tributária do IBS e da CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpRetornoComplementarIBSCBS">
+		<xs:annotation>
+			<xs:documentation>Informações complementares referente ao IBS e à CBS.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Adquirente" type="tipos:tpInformacoesPessoa" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Adquirente.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorBCIBSCBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da base de cálculo (BC) do IBS/CBS antes das reducões para cálculo do tributo bruto.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorAliqEstadualIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Alíquota do IBS de competência do Estado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorPercRedEstadualIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de alíquota estadual do IBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorAliqEfetivaEstadualIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Alíquota efetiva estadual do IBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorEstadualIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor do Tributo do IBS da UF calculado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorAliqMunicipalIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Alíquota do IBS de competência do Município.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorPercRedMunicipalIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota municipal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorAliqEfetivaMunicipalIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Alíquota efetiva municipal do IBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorMunicipalIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor do Tributo do IBS do Município calculado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS Total.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorAliqCBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Alíquota da CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorPercRedCBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Percentual da redução de alíquota para a CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorAliqEfetivaCBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Alíquota efetiva CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorCBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor do Tributo da CBS calculado. Total Valor da CBS da União.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorPercDiferimentoEstadual" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Percentual de diferimento estadual.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorDiferimentoEstadual" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Total do Diferimento do IBS estadual.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorPercDiferimentoMunicipal" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Percentual de diferimento municipal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorDiferimentoMunicipal" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Total do Diferimento do IBS municipal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorPercDiferimentoCBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Percentual de diferimento da CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorDiferimentoCBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Total do Diferimento CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CodigoClassCredPresumidoIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código e classificação do crédito presumido IBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorPercCredPresumidoIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Alíquota do Crédito Presumido para o IBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorCredPresumidoIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor do Crédito Presumido para o IBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CodigoClassCredPresumidoCBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código de Classificação do Crédito Presumido CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorPercCredPresumidoCBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Alíquota de crédito presumido para a CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorCredPresumidoCBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor do Crédito Presumido CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorAliqEstadualRegularIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Alíquota efetiva de tributação regular do IBS estadual.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorAliqMunicipalRegularIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Alíquota efetiva de tributação regular do IBS municipal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorAliqRegularCBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Alíquota efetiva de tributação regular da CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorEstadualRegularIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da tributação regular do IBS estadual.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorMunicipalRegularIBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da tributação regular do IBS municipal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorRegularCBS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da tributação regular da CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorTotalReeRepRes" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor total dos valores não inclusos na base de cálculo, somatória dos valores informados pelo contribuinte no campo vlrReeRepRes.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorAliqEstadualIBSCompraGov" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da alíquota estadual para o IBS, referente a compra governamental.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorEstadualBSCompraGov" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS estadual referente a compra governamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorAliqMunicipalIBSCompraGov" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da alíquota municipal para o IBS, referente a compra governamental.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorMunicipalIBSCompraGov" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS municipal referente a compra governamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorAliqCBSCompraGov" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da alíquota da CBS, referente a compra governamental.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorCBSCompraGov" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS referente a compra governamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpTrib">
+		<xs:annotation>
+			<xs:documentation>Informações relacionadas aos tributos IBS e à CBS.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="gIBSCBS" type="tipos:tpGIBSCBS" minOccurs="1" maxOccurs="1" />
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpValores">
+		<xs:annotation>
+			<xs:documentation>Informações relacionadas aos valores do serviço prestado para IBS e à CBS.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="gReeRepRes" type="tipos:tpGrupoReeRepRes" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações relativas a valores incluídos neste documento e recebidos por </xs:documentation>
+					<xs:documentation>motivo de estarem relacionadas a operações de terceiros, objeto de reembolso, repasse ou </xs:documentation>
+					<xs:documentation>ressarcimento pelo recebedor, já tributados e aqui referenciados.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="trib" type="tipos:tpTrib" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações relacionados aos tributos IBS e CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo que representa uma NFS-e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Assinatura" type="tipos:tpAssinatura" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Assinatura digital da NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ChaveNFe" type="tipos:tpChaveNFe" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Chave de identificação da NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DataEmissaoNFe" type="xs:dateTime" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Data de emissão da NFS-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NumeroLote" type="tipos:tpNumero" minOccurs ="0" maxOccurs ="1">
+				<xs:annotation>
+					<xs:documentation>Número de lote gerador da NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ChaveRPS" type="tipos:tpChaveRPS" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Chave do RPS que originou a NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TipoRPS" type="tipos:tpTipoRPS" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Tipo do RPS emitido.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DataEmissaoRPS" type="xs:date" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Data de emissão do RPS que originou a NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DataFatoGeradorNFe" type="xs:dateTime" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Data do fato gerador da NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CPFCNPJPrestador" type="tipos:tpCPFCNPJ" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>CPF/CNPJ do Prestador do serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RazaoSocialPrestador" type="tipos:tpRazaoSocial" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Nome/Razão Social do Prestador.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="EnderecoPrestador" type="tipos:tpEndereco" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Endereço do Prestador.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="EmailPrestador" type="tipos:tpEmail" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>E-mail do Prestador.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StatusNFe" type="tipos:tpStatusNFe" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Status da NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DataCancelamento" type="xs:dateTime" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Data de cancelamento da NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TributacaoNFe" type="tipos:tpTributacaoNFe" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Tributação da NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OpcaoSimples" type="tipos:tpOpcaoSimples" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Opção pelo Simples.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NumeroGuia" type="tipos:tpNumero" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Número da guia vinculada a NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DataQuitacaoGuia" type="xs:date" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Data de quitação da guia vinculada a NFS-e.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorServicos" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor dos serviços prestados.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorDeducoes" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor das deduções.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorPIS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da retenção do PIS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorCOFINS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da retenção do COFINS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorINSS" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da retenção do INSS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorIR" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da retenção do IR.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorCSLL" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da retenção do CSLL.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CodigoServico" type="tipos:tpCodigoServico" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código do serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AliquotaServicos" type="tipos:tpAliquota" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da alíquota.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorISS" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor do ISS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorCredito" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor do crédito gerado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ISSRetido" type="xs:boolean" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Retenção do ISS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CPFCNPJTomador" type="tipos:tpCPFCNPJNIF" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>CPF/CNPJ do tomador do serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="InscricaoMunicipalTomador" type="tipos:tpInscricaoMunicipal" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Inscrição Municipal do Tomador.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="InscricaoEstadualTomador" type="tipos:tpInscricaoEstadual" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Inscrição Estadual do tomador.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RazaoSocialTomador" type="tipos:tpRazaoSocial" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Nome/Razão Social do tomador.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="EnderecoTomador" type="tipos:tpEndereco" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Endereço do tomador.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="EmailTomador" type="tipos:tpEmail" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>E-mail do tomador.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CPFCNPJIntermediario" type="tipos:tpCPFCNPJ" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>CNPJ do intermediário de serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="InscricaoMunicipalIntermediario" type="tipos:tpInscricaoMunicipal" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Inscrição Municipal do intermediário de serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ISSRetidoIntermediario" type="xs:string" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Retenção do ISS pelo intermediário de serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="EmailIntermediario" type="tipos:tpEmail" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>E-mail do intermediário de serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Discriminacao" type="tipos:tpDiscriminacao" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Descrição dos serviços.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorCargaTributaria" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da carga tributária total em R$.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PercentualCargaTributaria" type="tipos:tpPercentualCargaTributaria" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor percentual da carga tributária.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FonteCargaTributaria" type="tipos:tpFonteCargaTributaria" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Fonte de informação da carga tributária.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CodigoCEI" type="tipos:tpNumero" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código do CEI - Cadastro específico do INSS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="MatriculaObra" type="tipos:tpNumero" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código que representa a matrícula da obra no sistema de cadastro de obras.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="MunicipioPrestacao" type="tipos:tpCidade" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código da cidade do município da prestação do serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NumeroEncapsulamento" type="tipos:tpNumero" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código que representa o número do encapsulamento da obra.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorTotalRecebido" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor do total recebido.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RetencaoPisCofins" type="tipos:tpRetencaoPisCofins" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Tipo de retenção para os tributos federais PIS/COFINS e CSLL</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element name="ValorInicialCobrado" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation>Valor inicial cobrado pela prestação do serviço, antes de tributos, multa e juros.</xs:documentation>
+						<xs:documentation>"Valor dos serviços antes dos tributos". Corresponde ao valor cobrado pela prestação do serviço, antes de tributos, multa e juros.</xs:documentation>
+						<xs:documentation>Informado para realizar o cálculo dos tributos do início para o fim.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="ValorFinalCobrado" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation>Valor final cobrado pela prestação do serviço, incluindo todos os tributos.</xs:documentation>
+						<xs:documentation>"Valor total na nota". Corresponde ao valor final cobrado pela prestação do serviço, incluindo todos os tributos, multa e juros.</xs:documentation>
+						<xs:documentation>Informado para realizar o cálculo dos impostos do fim para o início.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="ValorMulta" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da multa.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorJuros" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor dos juros.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorIPI" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor de IPI.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ExigibilidadeSuspensa" type="tipos:tpNaoSim" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Indica se é uma emissão com exigibilidade suspensa.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PagamentoParceladoAntecipado" type="tipos:tpNaoSim" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Indica de nota fiscal de pagamento parcelado antecipado (realizado antes do fornecimento).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NCM" type="tipos:tpCodigoNCM" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o número NCM (Nomenclatura Comum do Mercosul).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NBS" type="tipos:tpCodigoNBS" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o número NBS (Nomenclatura Brasileira de Serviços).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="atvEvento" type="tipos:tpAtividadeEvento" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informações dos Tipos de evento.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:group ref="tipos:gpPrestacao" minOccurs="0" />
+			<xs:element name="IBSCBS" type="tipos:tpIBSCBS" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informações declaradas pelo emitente referentes ao IBS e à CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RetornoComplementarIBSCBS" type="tipos:tpRetornoComplementarIBSCBS" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informações complementares referentes ao IBS e à CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="tpRPS">
+		<xs:annotation>
+			<xs:documentation>Tipo que representa um RPS.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Assinatura" type="tipos:tpAssinatura" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Assinatura digital do RPS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ChaveRPS" type="tipos:tpChaveRPS" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe a chave do RPS emitido.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TipoRPS" type="tipos:tpTipoRPS" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o Tipo do RPS emitido.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DataEmissao" type="xs:date" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe a Data de emissão do RPS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StatusRPS" type="tipos:tpStatusNFe" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o Status do RPS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TributacaoRPS" type="tipos:tpTributacaoNFe" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o tipo de tributação do RPS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorDeducoes" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o valor das deduções.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorPIS" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o valor da retenção do PIS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorCOFINS" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o valor da retenção do COFINS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorINSS" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o valor da retenção do INSS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorIR" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o valor da retenção do IR.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorCSLL" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o valor da retenção do CSLL.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CodigoServico" type="tipos:tpCodigoServico" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o código do serviço do RPS. Este código deve pertencer à lista de serviços.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AliquotaServicos" type="tipos:tpAliquota" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o valor da alíquota. Obs. O conteúdo deste campo será ignorado caso a tributação ocorra no município (Situação do RPS = T ).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ISSRetido" type="xs:boolean" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe a retenção.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CPFCNPJTomador" type="tipos:tpCPFCNPJNIF" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o CPF/CNPJ do tomador do serviço. O conteúdo deste campo será ignorado caso o campo InscricaoMunicipalTomador esteja preenchido.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="InscricaoMunicipalTomador" type="tipos:tpInscricaoMunicipal" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe a Inscrição Municipal do Tomador. ATENÇÃO: Este campo só deverá ser preenchido para tomadores estabelecidos no município de São Paulo (CCM). Quando este campo for preenchido, seu conteúdo será considerado como prioritário com relação ao campo de CPF/CNPJ do Tomador, sendo utilizado para identificar o Tomador e recuperar seus dados da base de dados da Prefeitura.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="InscricaoEstadualTomador" type="tipos:tpInscricaoEstadual" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe a inscrição estadual do tomador. Este campo será ignorado caso seja fornecido um CPF/CNPJ ou a Inscrição Municipal do tomador pertença ao município de São Paulo.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RazaoSocialTomador" type="tipos:tpRazaoSocial" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o Nome/Razão Social do tomador. Este campo é obrigatório apenas para tomadores Pessoa Jurídica (CNPJ). Este campo será ignorado caso seja fornecido um CPF/CNPJ ou a Inscrição Municipal do tomador pertença ao município de São Paulo.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="EnderecoTomador" type="tipos:tpEndereco" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o endereço do tomador. Os campos do endereço são obrigatórios apenas para tomadores pessoa jurídica (CNPJ informado). O conteúdo destes campos será ignorado caso seja fornecido um CPF/CNPJ ou a Inscrição Municipal do tomador pertença ao município de São Paulo.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="EmailTomador" type="tipos:tpEmail" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o e-mail do tomador.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CPFCNPJIntermediario" type="tipos:tpCPFCNPJ" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>CNPJ do intermediário de serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="InscricaoMunicipalIntermediario" type="tipos:tpInscricaoMunicipal" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Inscrição Municipal do intermediário de serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ISSRetidoIntermediario" type="xs:string" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Retenção do ISS pelo intermediário de serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="EmailIntermediario" type="tipos:tpEmail" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>E-mail do intermediário de serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Discriminacao" type="tipos:tpDiscriminacao" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe a discriminação dos serviços.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorCargaTributaria" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da carga tributária total em R$.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PercentualCargaTributaria" type="tipos:tpPercentualCargaTributaria" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor percentual da carga tributária.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FonteCargaTributaria" type="tipos:tpFonteCargaTributaria" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Fonte de informação da carga tributária.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CodigoCEI" type="tipos:tpNumero" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código do CEI - Cadastro específico do INSS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="MatriculaObra" type="tipos:tpNumero" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código que representa a matrícula da obra no sistema de cadastro de obras.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="MunicipioPrestacao" type="tipos:tpCidade" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código da cidade do município da prestação do serviço.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NumeroEncapsulamento" type="tipos:tpNumero" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Código que representa o número do encapsulamento da obra.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorTotalRecebido" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor do total recebido.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RetencaoPisCofins" type="tipos:tpRetencaoPisCofins" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Tipo de retenção para os tributos federais PIS/COFINS e CSLL</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice>
+				<xs:element name="ValorInicialCobrado" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation>Valor inicial cobrado pela prestação do serviço, antes de tributos, multa e juros.</xs:documentation>
+						<xs:documentation>"Valor dos serviços antes dos tributos". Corresponde ao valor cobrado pela prestação do serviço, antes de tributos, multa e juros.</xs:documentation>
+						<xs:documentation>Informado para realizar o cálculo dos tributos do início para o fim.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="ValorFinalCobrado" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+					<xs:annotation>
+						<xs:documentation>Valor final cobrado pela prestação do serviço, incluindo todos os tributos.</xs:documentation>
+						<xs:documentation>"Valor total na nota". Corresponde ao valor final cobrado pela prestação do serviço, incluindo todos os tributos, multa e juros.</xs:documentation>
+						<xs:documentation>Informado para realizar o cálculo dos impostos do fim para o início.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="ValorMulta" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor da multa.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorJuros" type="tipos:tpValor" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor dos juros.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ValorIPI" type="tipos:tpValor" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Valor de IPI.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ExigibilidadeSuspensa" type="tipos:tpNaoSim" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe se é uma emissão com exigibilidade suspensa.</xs:documentation>
+					<xs:documentation>0 - Não.</xs:documentation>
+					<xs:documentation>1 - Sim.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PagamentoParceladoAntecipado" type="tipos:tpNaoSim" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe a nota fiscal de pagamento parcelado antecipado (realizado antes do fornecimento).</xs:documentation>
+					<xs:documentation>0 - Não.</xs:documentation>
+					<xs:documentation>1 - Sim.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NCM" type="tipos:tpCodigoNCM" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o número NCM (Nomenclatura Comum do Mercosul).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NBS" type="tipos:tpCodigoNBS" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informe o número NBS (Nomenclatura Brasileira de Serviços).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="atvEvento" type="tipos:tpAtividadeEvento" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informações dos Tipos de evento.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:group ref="tipos:gpPrestacao" />
+			<xs:element name="IBSCBS" type="tipos:tpIBSCBS" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informações declaradas pelo emitente referentes ao IBS e à CBS.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/xmldsig-core-schema_v02.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/ISSSaoPaulo/1.00/xmldsig-core-schema_v02.xsd
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Schema específico para assinaturas XML a partir de certificados do padrão ICP-Brasil (X509) -->
+<xs:schema targetNamespace="http://www.w3.org/2000/09/xmldsig#" 
+        xmlns:ds="http://www.w3.org/2000/09/xmldsig#" 
+        xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+        elementFormDefault="qualified" 
+        attributeFormDefault="unqualified" version="0.1">
+  <xs:element name="Signature" type="ds:SignatureType"/>
+  <xs:complexType name="SignatureType">
+    <xs:sequence>
+      <xs:element name="SignedInfo" type="ds:SignedInfoType"/>
+      <xs:element name="SignatureValue" type="ds:SignatureValueType"/>
+      <xs:element name="KeyInfo" type="ds:KeyInfoType"/>
+		</xs:sequence>
+    <xs:attribute name="Id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+  <xs:complexType name="SignatureValueType">
+    <xs:simpleContent>
+      <xs:extension base="xs:base64Binary">
+        <xs:attribute name="Id" type="xs:ID" use="optional"/>
+			</xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="SignedInfoType">
+    <xs:sequence>
+      <xs:element name="CanonicalizationMethod">
+        <xs:complexType>
+          <xs:attribute name="Algorithm" type="xs:anyURI" use="required"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="SignatureMethod">
+        <xs:complexType>
+          <xs:attribute name="Algorithm" type="xs:anyURI" use="required"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Reference" type="ds:ReferenceType" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="Id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+  <xs:complexType name="ReferenceType">
+    <xs:sequence>
+      <xs:element name="Transforms" type="ds:TransformsType"/>
+      <xs:element name="DigestMethod">
+        <xs:complexType>
+          <xs:attribute name="Algorithm" type="xs:anyURI" use="required"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="DigestValue" type="ds:DigestValueType"/>
+    </xs:sequence>
+    <xs:attribute name="Id" type="xs:ID" use="optional"/>
+    <xs:attribute name="URI" type="xs:anyURI" use="optional"/>
+    <xs:attribute name="Type" type="xs:anyURI" use="optional"/>
+  </xs:complexType>
+  <xs:complexType name="TransformsType">
+    <xs:sequence>
+      <xs:element name="Transform" type="ds:TransformType" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TransformType">
+    <xs:sequence minOccurs="0" maxOccurs="unbounded">
+      <xs:element name="XPath" type="xs:string"/>
+    </xs:sequence>
+    <xs:attribute name="Algorithm" type="xs:anyURI" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="KeyInfoType">
+    <xs:sequence>
+      <xs:element name="X509Data" type="ds:X509DataType"/>
+    </xs:sequence>
+    <xs:attribute name="Id" type="xs:ID" use="optional"/>
+  </xs:complexType>
+  <xs:complexType name="KeyValueType">
+    <xs:sequence>
+      <xs:element name="RSAKeyValue">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="Modulus" type="ds:CryptoBinary"/>
+            <xs:element name="Exponent" type="ds:CryptoBinary"/>
+					</xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="X509DataType">
+    <xs:sequence>
+      <xs:element name="X509Certificate" type="xs:base64Binary"/>
+    </xs:sequence>
+  </xs:complexType>
+	<!-- Basic Types Defined for Signatures -->
+  <xs:simpleType name="CryptoBinary">
+    <xs:restriction base="xs:base64Binary"/>
+	</xs:simpleType>
+  <xs:simpleType name="DigestValueType">
+    <xs:restriction base="xs:base64Binary"/>
+  </xs:simpleType>
+</xs:schema>

--- a/src/OpenAC.Net.NFSe/Schemas/Tiplan/2.03/nfse.xsd
+++ b/src/OpenAC.Net.NFSe/Schemas/Tiplan/2.03/nfse.xsd
@@ -674,9 +674,33 @@
         04 - Operação Tributável monofásica - Revenda a Alíquota Zero;
         05 - Operação Tributável por Substituição Tributária;
         06 - Operação Tributável a Alíquota Zero;
-        07 - Operação Tributável da Contribuição;
+        07 - Operação Isenta da Contribuição;
         08 - Operação sem Incidência da Contribuição;
         09 - Operação com Suspensão da Contribuição;
+        49 - Outras Operações de Saída;
+        50 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Tributada no Mercado Interno;
+        51 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno;
+        52 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita de Exportação;
+        53 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno;
+        54 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas no Mercado Interno e de Exportação;
+        55 - Operação com Direito a Crédito – Vinculada a Receitas Não Tributadas no Mercado Interno e de Exportação;
+        56 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação;
+        60 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno;
+        61 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno;
+        62 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação;
+        63 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno;
+        64 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação;
+        65 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação;
+        66 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação;
+        67 - Crédito Presumido – Outras Operações;
+        70 - Operação de Aquisição sem Direito a Crédito;
+        71 - Operação de Aquisição com Isenção;
+        72 - Operação de Aquisição com Suspensão;
+        73 - Operação de Aquisição a Alíquota Zero;
+        74 - Operação de Aquisição sem Incidência da Contribuição;
+        75 - Operação de Aquisição por Substituição Tributária;
+        98 - Outras Operações de Entrada;
+        99 - Outras Operações;
       </xsd:documentation>
     </xsd:annotation>
     <xsd:restriction base="xsd:string">
@@ -691,6 +715,30 @@
       <xsd:enumeration value="07"/>
       <xsd:enumeration value="08"/>
       <xsd:enumeration value="09"/>
+      <xsd:enumeration value="49"/>
+      <xsd:enumeration value="50"/>
+      <xsd:enumeration value="51"/>
+      <xsd:enumeration value="52"/>
+      <xsd:enumeration value="53"/>
+      <xsd:enumeration value="54"/>
+      <xsd:enumeration value="55"/>
+      <xsd:enumeration value="56"/>
+      <xsd:enumeration value="60"/>
+      <xsd:enumeration value="61"/>
+      <xsd:enumeration value="62"/>
+      <xsd:enumeration value="63"/>
+      <xsd:enumeration value="64"/>
+      <xsd:enumeration value="65"/>
+      <xsd:enumeration value="66"/>
+      <xsd:enumeration value="67"/>
+      <xsd:enumeration value="70"/>
+      <xsd:enumeration value="71"/>
+      <xsd:enumeration value="72"/>
+      <xsd:enumeration value="73"/>
+      <xsd:enumeration value="74"/>
+      <xsd:enumeration value="75"/>
+      <xsd:enumeration value="98"/>
+      <xsd:enumeration value="99"/>
     </xsd:restriction>
   </xsd:simpleType>
   <xsd:simpleType name="tsIndFinal">
@@ -890,9 +938,17 @@
       <xsd:element name="SituacaoTributariaPISCOFINS" type="tsSituacaoTributariaPISCOFINS" minOccurs="0"
         maxOccurs="1" />
       <xsd:element name="AliquotaPis" type="tsAliquota" minOccurs="0"
-				maxOccurs="1" />
+				maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>Este campo está obsoleto e não deve ser utilizado.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
       <xsd:element name="AliquotaCofins" type="tsAliquota" minOccurs="0"
-				maxOccurs="1" />
+				maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>Este campo está obsoleto e não deve ser utilizado.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
     </xsd:sequence>
   </xsd:complexType>
 


### PR DESCRIPTION
Geração do grupo IBS/CBS no provider Tiplan 2.03.
Suporte ao layout 2 do ISS São Paulo, mantendo o layout 1 como padrão.
Adição de testes para os dois providers (SP e Tiplan).
Atualização dos schemas.